### PR TITLE
[fix] H2 reclamation across CM and Full GC

### DIFF
--- a/allocator/include/regions.h
+++ b/allocator/include/regions.h
@@ -29,8 +29,9 @@ extern "C" {
   };
 
   struct region_list {
-    char *start;
-    char *end;
+    char *region_start;
+    char *last_allocated_start;
+    char *last_allocated_end;
     struct region_list *next;
   };
 

--- a/allocator/include/segments.h
+++ b/allocator/include/segments.h
@@ -5,6 +5,9 @@
 #include <stdlib.h>
 #include <stdbool.h>
 
+// #define DBG_LOST_REGION
+// #define DBG_PROTECT_FREE_REGIONS
+
 #define ANONYMOUS 0
 #define PR_BUFFER 1
 #define PR_BUFFER_SIZE (2*1024LU*1024) /* Promotion buffer size */
@@ -283,5 +286,9 @@ void buffer_insert(char* obj, char* new_adr, size_t size);
 void free_all_buffers();
 
 #endif
+
+/* Returns the number of regions that were reclaimed (i.e., released back
+to the free pool) during the most recent reclamation cycle. */
+uint num_reclaimed_regions(void);
 
 #endif

--- a/allocator/include/sharedDefines.h
+++ b/allocator/include/sharedDefines.h
@@ -25,7 +25,7 @@
 
 #define MALLOC_ON	1				            //< Allocate buffers dynamically
 
-#define REGION_SIZE	(256*1024LU*1024) //< Region size (in bytes) for allignment
+#define REGION_SIZE	(32*1024LU*1024) //< Region size (in bytes) for allignment
 									                    // version
 
 #if ANONYMOUS

--- a/allocator/src/segments.c
+++ b/allocator/src/segments.c
@@ -39,6 +39,8 @@ double		  alloc_elapsedtime = 0.0;
 double		  free_elapsedtime = 0.0;
 #endif
 
+uint reclaimed_regions_count; 
+
 static inline void check_allocation_failure(void *ptr, const char *msg) {
   if (!ptr) {
     perror(msg);
@@ -170,7 +172,7 @@ char* new_region(size_t size) {
     mark_used(region_array[i].start_address);
   #endif /* ifdef DBG_LOST_REGION */
     references(region_array[cur_region].start_address, region_array[i].start_address);
-    //references(region_array[i].start_address, region_array[cur_region].start_address);
+    // references(region_array[i].start_address, region_array[cur_region].start_address);
     region_array[i].last_allocated_start = region_array[cur_region].start_address;
     region_array[i].first_allocated_start = region_array[cur_region].start_address;
     region_array[i].last_allocated_end = region_array[cur_region].start_address + size;
@@ -551,6 +553,7 @@ struct region_list* free_regions() {
 #endif
   int32_t i;
   struct region_list *head = NULL;
+  reclaimed_regions_count = 0;
   for (i = 0; i < region_array_size; i++) {
     if (region_array[i].used == 0 && region_array[i].last_allocated_end != region_array[i].start_address) {
       struct tera_group *ptr = region_array[i].dependency_list;
@@ -569,8 +572,9 @@ struct region_list* free_regions() {
 
       if (region_array[i].last_allocated_start >= region_array[i].start_address) {
         struct region_list *new_node = malloc(sizeof(struct region_list));
-        new_node->start = region_array[i].start_address;
-        new_node->end = region_array[i].last_allocated_start;
+        new_node->region_start = region_array[i].start_address;
+        new_node->last_allocated_start = region_array[i].last_allocated_start;
+        new_node->last_allocated_end = region_array[i].last_allocated_end;
         new_node->next = head;
         head = new_node;
       }
@@ -601,9 +605,7 @@ struct region_list* free_regions() {
 
       region_array[i].rdd_id = MAX_PARTITIONS * max_rdd_id;
 
-#if STATISTICS
-      fprintf(stderr, "Freeing region %d \n",i);
-#endif
+      reclaimed_regions_count++;
     }
   }
 
@@ -1023,3 +1025,9 @@ bool object_starts_from_region(char *obj) {
   return (region_array[seg].first_allocated_start != region_array[seg].start_address) ? false : true;
 }
 #endif
+
+/* Returns the number of regions that were reclaimed (i.e., released back
+to the free pool) during the most recent reclamation cycle. */
+uint num_reclaimed_regions(void) {
+  return reclaimed_regions_count;
+}

--- a/allocator/tests/th_allocate_multi_regions.c
+++ b/allocator/tests/th_allocate_multi_regions.c
@@ -59,9 +59,15 @@ int main() {
   
 
   reset_used();
+#ifdef DBG_LOST_REGION
+  mark_used(obj3, "testfile", 0);
+  mark_used(obj4, "testfile", 0);
+  mark_used(obj6, "testfile", 0);
+#else
   mark_used(obj3);
   mark_used(obj4);
   mark_used(obj6);
+#endif
   
   //obj2 should be in region 1 
   obj2 = allocate(64000, 10, 0);

--- a/allocator/tests/th_free.c
+++ b/allocator/tests/th_free.c
@@ -91,9 +91,15 @@ int main() {
   print_groups();
 
   reset_used();
+#ifdef DBG_LOST_REGION
+  mark_used(obj1, "testfile", 0);
+  mark_used(obj6, "testfile", 0);
+  mark_used(obj8, "testfile", 0);
+#else
   mark_used(obj1);
   mark_used(obj6);
   mark_used(obj8);
+#endif
 
   //nothing should be freed because all regions belong to the same tera_group 
   free_regions();
@@ -103,8 +109,13 @@ int main() {
   print_groups();
 
   reset_used();
+#ifdef DBG_LOST_REGION
+  mark_used(obj1, "testfile", 0);
+  mark_used(obj6, "testfile", 0);
+#else
   mark_used(obj1);
   mark_used(obj6);
+#endif
   assertf(total_used_regions() == 3,
           "Number of used regions is incorrect %lu", total_used_regions());
 

--- a/jdk17/src/hotspot/share/gc/g1/g1CodeBlobClosure.cpp
+++ b/jdk17/src/hotspot/share/gc/g1/g1CodeBlobClosure.cpp
@@ -48,6 +48,8 @@ void G1CodeBlobClosure::HeapRegionGatheringOopClosure::do_oop_work(T* p) {
       // 11 --
       const char *name = "G1CodeBlobClosure::HeapRegionGatheringOopClosure::do_oop_work";
       Universe::teraHeap()->mark_used_region(cast_from_oop<HeapWord*>(o), (char *) name);
+    #else 
+      Universe::teraHeap()->mark_used_region(cast_from_oop<HeapWord*>(o));
     #endif
       return;
     }

--- a/jdk17/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/jdk17/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -3037,7 +3037,6 @@ bool G1CollectedHeap::do_collection_pause_at_safepoint(double target_pause_time_
 
     Universe::teraHeap()->get_tera_stats()->print_gc_stats();
 
-    Universe::teraHeap()->get_tera_stats()->reset_counters();
   } else {
     do_collection_pause_at_safepoint_helper(target_pause_time_ms); 
   }
@@ -3184,11 +3183,8 @@ void G1CollectedHeap::do_collection_pause_at_safepoint_helper(double target_paus
           Universe::teraHeap()->h2_enable_rand_faults();
 
           if (collector_state()->in_concurrent_start_gc()) {
-          #ifdef DBG_LOST_REGION
             // Reset the used field of all regions
-            // NOTE: propably this should not be commented out
             Universe::teraHeap()->h2_reset_used_field();
-          #endif // DBG_LOST_REGION
           }
         }
 #endif       
@@ -3235,6 +3231,9 @@ void G1CollectedHeap::do_collection_pause_at_safepoint_helper(double target_paus
           // Wait to complete all the transfers to H2 and then continue
           // TODO: uncomment
           // Universe::teraHeap()->h2_complete_transfers();  
+          
+          if (collector_state()->in_young_gc_before_mixed())
+            Universe::teraHeap()->free_unused_regions();
         }
 #endif
 
@@ -3370,6 +3369,8 @@ bool G1STWIsAliveClosure::do_object_b(oop p) {
     // 8
     const char *name = "G1STWIsAliveClosure::do_object_b";
     Universe::teraHeap()->mark_used_region(cast_from_oop<HeapWord*>(p), (char *) name);
+  #else
+    Universe::teraHeap()->mark_used_region(cast_from_oop<HeapWord*>(p));
   #endif // DBG_LOST_REGION
     return true;
   }
@@ -3381,12 +3382,6 @@ bool G1STWIsAliveClosure::do_object_b(oop p) {
 }
 
 bool G1STWSubjectToDiscoveryClosure::do_object_b(oop obj) {
-
-#ifdef TERA_MAINTENANCE 
-  if (EnableTeraHeap && Universe::teraHeap()->is_in_h2(obj))
-    return false;
-#endif
-
   assert(obj != NULL, "must not be NULL");
   assert(_g1h->is_in_reserved(obj), "Trying to discover obj " PTR_FORMAT " not in heap", p2i(obj));
 
@@ -3397,6 +3392,8 @@ bool G1STWSubjectToDiscoveryClosure::do_object_b(oop obj) {
     // 9
     const char *name = "G1STWSubjectToDiscoveryClosure::do_object_b";
     Universe::teraHeap()->mark_used_region(cast_from_oop<HeapWord*>(obj), (char *) name);
+  #else
+    Universe::teraHeap()->mark_used_region(cast_from_oop<HeapWord*>(obj));
   #endif // DBG_LOST_REGION
     return true;
   }
@@ -3418,12 +3415,16 @@ public:
     oop obj = *p;
     assert(obj != NULL, "the caller should have filtered out NULL values");
 
+    guarantee(!Universe::teraHeap()->is_in_h2((HeapWord *) p), "Field is in H2");
+
 #ifdef TERA_MAINTENANCE
     if( EnableTeraHeap && Universe::teraHeap()->is_in_h2(obj) ) {
     #ifdef DBG_LOST_REGION
       // 10
       const char *name = "G1KeepAliveClosure::do_oop";
       Universe::teraHeap()->mark_used_region(cast_from_oop<HeapWord*>(obj), (char *) name);
+    #else
+      Universe::teraHeap()->mark_used_region(cast_from_oop<HeapWord*>(obj));
     #endif // DBG_LOST_REGION
       return;
     }
@@ -3436,6 +3437,7 @@ public:
     if (region_attr.is_in_cset()) {
       assert( obj->is_forwarded(), "invariant" );
       *p = obj->forwardee();
+      //guarantee(!Universe::teraHeap()->is_in_h2(obj->forwardee()), "make region live???");
     } else {
       assert(!obj->is_forwarded(), "invariant" );
       assert(region_attr.is_humongous(),
@@ -3466,6 +3468,9 @@ public:
 
   template <class T> void do_oop_work(T* p) {
     oop obj = RawAccess<>::oop_load(p);
+
+    guarantee(!Universe::teraHeap()->is_in_h2((HeapWord *) p), "P should not be in H2");
+    guarantee(!Universe::teraHeap()->is_in_h2(obj), "obj should not be in H2");
 
     if (_g1h->is_in_cset_or_humongous(obj)) {
       // If the referent object has been forwarded (either copied
@@ -4492,7 +4497,17 @@ class UnregisterNMethodOopClosure: public OopClosure {
 #if defined TERA_C1 || defined TERA_C2
       // if the nmethod is pointing to an h2 obj
       // no need to unregister the nmethod from the rem set (bcs there are no rem sets in h2)
-      if (EnableTeraHeap && Universe::teraHeap()->is_in_h2(obj)) return;
+      guarantee(!Universe::teraHeap()->is_in_h2((HeapWord *)p), "error");
+      if (EnableTeraHeap && Universe::teraHeap()->is_in_h2(obj)) {
+#ifdef DBG_LOST_REGION
+        // 8
+        const char *name = "UnregisterNMethodOopClosrure::do_oop_work";
+        Universe::teraHeap()->mark_used_region(cast_from_oop<HeapWord*>(obj), (char *) name);
+#else
+        Universe::teraHeap()->mark_used_region(cast_from_oop<HeapWord*>(obj));
+#endif // DBG_LOST_REGION
+        return;
+      }
 #endif
 
       HeapRegion* hr = _g1h->heap_region_containing(obj);

--- a/jdk17/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/jdk17/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -1231,15 +1231,6 @@ void G1ConcurrentMark::remark() {
       reclaim_empty_regions();
     }
 
-#if defined(TERA_MAINTENANCE) && defined(DBG_LOST_REGION)
-    if (EnableTeraHeap) {
-      // NOTE: this code was previously in "cleanup"
-      // Free all the regions that are unused after marking
-      // fprintf(stderr, "[WARNING] CM free of H2 regions is disabled!\n");
-      Universe::teraHeap()->free_unused_regions();
-    }
-#endif
-
     // Clean out dead classes
     if (ClassUnloadingWithConcurrentMark) {
       GCTraceTime(Debug, gc, phases) debug("Purge Metaspace", _gc_timer_cm);
@@ -1701,9 +1692,10 @@ public:
     #ifdef DBG_LOST_REGION
       // TODO: should we mark region live here? --> caused error again
       // 3
-      // Universe::teraHeap()->mark_used_region(cast_from_oop<HeapWord*>(obj));
       const char *name = "G1ObjectCountIsAliveClosure::do_object_b";
       Universe::teraHeap()->mark_used_region(cast_from_oop<HeapWord*>(obj), (char *) name);
+    #else
+      Universe::teraHeap()->mark_used_region(cast_from_oop<HeapWord*>(obj));
     #endif // DBG_LOST_REGION
       return true;
     }

--- a/jdk17/src/hotspot/share/gc/g1/g1ConcurrentMark.inline.hpp
+++ b/jdk17/src/hotspot/share/gc/g1/g1ConcurrentMark.inline.hpp
@@ -46,9 +46,10 @@ inline bool G1CMIsAliveClosure::do_object_b(oop obj) {
   #ifdef DBG_LOST_REGION
     // TODO: should we mark region live here? --> caused error again
     // 1
-    // Universe::teraHeap()->mark_used_region(cast_from_oop<HeapWord*>(obj));
     const char *name = "G1CMIsAliveClosure::do_object_b";
     Universe::teraHeap()->mark_used_region(cast_from_oop<HeapWord*>(obj), (char *) name);
+  #else 
+    Universe::teraHeap()->mark_used_region(cast_from_oop<HeapWord*>(obj));
   #endif // DBG_LOST_REGION
     return true;
   }
@@ -76,9 +77,10 @@ inline bool G1CMSubjectToDiscoveryClosure::do_object_b(oop obj) {
   #ifdef DBG_LOST_REGION
     // TODO: should we mark region live here? --> caused error again
     // 2
-    // Universe::teraHeap()->mark_used_region(cast_from_oop<HeapWord*>(obj));
     const char *name = "G1CMSubjectToDiscoveryClosure::do_object_b";
     Universe::teraHeap()->mark_used_region(cast_from_oop<HeapWord*>(obj), (char *) name);
+  #else 
+    Universe::teraHeap()->mark_used_region(cast_from_oop<HeapWord*>(obj));
   #endif // DBG_LOST_REGION
     return true;
   }

--- a/jdk17/src/hotspot/share/gc/g1/g1ConcurrentMarkThread.cpp
+++ b/jdk17/src/hotspot/share/gc/g1/g1ConcurrentMarkThread.cpp
@@ -277,14 +277,6 @@ void G1ConcurrentMarkThread::concurrent_mark_cycle_do() {
   HandleMark hm(Thread::current());
   ResourceMark rm;
 
-  // Reset to find unused regions in H2.
-  if (EnableTeraHeap) {
-  #ifdef DBG_LOST_REGION
-    // NOTE: this is propably not correct here
-    // Universe::teraHeap()->h2_reset_used_field();
-  #endif // DBG_LOST_REGION
-  }
-
   // Phase 1: Clear CLD claimed marks.
   phase_clear_cld_claimed_marks();
 

--- a/jdk17/src/hotspot/share/gc/g1/g1FullCollector.hpp
+++ b/jdk17/src/hotspot/share/gc/g1/g1FullCollector.hpp
@@ -50,6 +50,14 @@ class ReferenceProcessor;
 class G1FullGCSubjectToDiscoveryClosure: public BoolObjectClosure {
 public:
   bool do_object_b(oop p) {
+    if (EnableTeraHeap && Universe::teraHeap()->is_in_h2(p)) {
+  #ifdef DBG_LOST_REGION
+      const char *name = "G1FullGCSubjectToDiscoveryClosure::do_object_b";
+      Universe::teraHeap()->mark_used_region(cast_from_oop<HeapWord*>(p), (char *) name);
+  #else
+      Universe::teraHeap()->mark_used_region(cast_from_oop<HeapWord*>(p));
+  #endif // DBG_LOST_REGION
+    }
     assert(p != NULL, "must be");
     return true;
   }

--- a/jdk17/src/hotspot/share/gc/g1/g1FullCollector.inline.hpp
+++ b/jdk17/src/hotspot/share/gc/g1/g1FullCollector.inline.hpp
@@ -83,7 +83,7 @@ inline bool G1FullCollector::h2_should_trace(T* p) {
   Universe::teraHeap()->h2_push_backward_reference((void *)p, obj);
   G1HeapRegionAttr region_attr = g1h->region_attr(obj);
 
-  g1h->th_card_table()->inline_write_ref_field_gc((void *) p, obj, !(g1h->is_in_young(obj) || region_attr.is_humongous()));
+  g1h->th_card_table()->inline_write_ref_field_gc((void *) p, obj, !(g1h->is_in_young(obj) || g1h->heap_region_containing(obj)->is_humongous()));
 
   return false;
 }

--- a/jdk17/src/hotspot/share/gc/g1/g1FullGCOopClosures.inline.hpp
+++ b/jdk17/src/hotspot/share/gc/g1/g1FullGCOopClosures.inline.hpp
@@ -71,18 +71,26 @@ template <class T> inline void G1AdjustClosure::adjust_pointer(T* p) {
 
   oop obj = CompressedOops::decode_not_null(heap_oop);
   assert(Universe::heap()->is_in(obj) || Universe::teraHeap()->is_in_h2(obj), "should be in heap");
+
+  // Case 1: The reference already points into H2.
+  // No pointer adjustment is needed, but we must record the cross-heap /
+  // cross-H2-region metadata for this reference slot (e.g., region dependency
+  // tracking).
   if (EnableTeraHeap && Universe::teraHeap()->is_in_h2(obj)) {
-    // We never move objects in H2 so we shouldn't need to process them.
+    Universe::teraHeap()->check_for_cross_heap_cross_h2_region_ref(_worker_id, cast_from_oop<HeapWord*>(obj), (void *) p);
     return;
   }
+
+  // Case 2: The referent `obj` will not move (not in a compacting region and
+  // not marked for H2 migration). The slot `p` is already correct, so we can
+  // skip forwarding logic. We still run TeraHeap bookkeeping for the reference
+  // slot (cross-heap/region deps or card marking), if enabled.
   if (!_collector->is_compacting(obj) && !obj->is_marked_move_h2()) {
     // We never forward objects in non-compacting regions so there is no need to
     // process them further.
-    // TODO: probably remove this assertion
     assert(!Universe::teraHeap()->is_in_h2(obj->forwardee()), "Object in non-compacting region moves to H2 without being marked.");
-    // TODO: all tests pass even without this line
     if (EnableTeraHeap)
-      Universe::teraHeap()->thread_group_region_enabled(_worker_id, cast_from_oop<HeapWord*>(obj), (void *) p);
+      Universe::teraHeap()->check_for_cross_heap_cross_h2_region_ref(_worker_id, cast_from_oop<HeapWord*>(obj), (void *) p);
     return;
   }
 
@@ -96,8 +104,7 @@ template <class T> inline void G1AdjustClosure::adjust_pointer(T* p) {
            p2i(obj), obj->mark().value(), markWord::prototype_for_klass(obj->klass()).value());
 
     if (EnableTeraHeap)
-      Universe::teraHeap()->thread_group_region_enabled(_worker_id, cast_from_oop<HeapWord*>(obj), (void *) p);
-    
+      Universe::teraHeap()->check_for_cross_heap_cross_h2_region_ref(_worker_id, cast_from_oop<HeapWord*>(obj), (void *) p);
     return;
   }
 
@@ -108,7 +115,7 @@ template <class T> inline void G1AdjustClosure::adjust_pointer(T* p) {
     "should be in object space or H2");
 
   if (EnableTeraHeap)
-    Universe::teraHeap()->thread_group_region_enabled(_worker_id, cast_from_oop<HeapWord*>(forwardee), (void *) p);
+    Universe::teraHeap()->check_for_cross_heap_cross_h2_region_ref(_worker_id, cast_from_oop<HeapWord*>(forwardee), (void *) p);
 
 
 #ifdef TERA_DBG_PHASES

--- a/jdk17/src/hotspot/share/gc/g1/g1OopClosures.inline.hpp
+++ b/jdk17/src/hotspot/share/gc/g1/g1OopClosures.inline.hpp
@@ -113,7 +113,7 @@ inline void G1ScanEvacuatedObjClosure::do_oop_work(T* p) {
   }
   
   oop obj = CompressedOops::decode_not_null(heap_oop);
-  assert(!Universe::teraHeap()->is_in_h2(p), "Parent is an h2 obj. wrong closure");
+  guarantee(!Universe::teraHeap()->is_in_h2(p), "Parent is an h2 obj. wrong closure");
 
 #ifdef TERA_MAINTENANCE
   // h1->h2 : Fence
@@ -122,6 +122,8 @@ inline void G1ScanEvacuatedObjClosure::do_oop_work(T* p) {
     // 5
     const char *name = "G1ScanEvacuatedObjClosure::do_oop_work";
     Universe::teraHeap()->mark_used_region(cast_from_oop<HeapWord*>(obj), (char *) name);
+  #else
+    Universe::teraHeap()->mark_used_region(cast_from_oop<HeapWord*>(obj));
   #endif // DBG_LOST_REGION
     return;
   }
@@ -208,6 +210,7 @@ inline void G1RootRegionScanClosure::do_oop_work(T* p) {
   // it is also iterated by oop_iterate.
   // So here we find all the outgoing pointers, from the root regions.
   // An outgoing pointer may be in H1 old gen or in H2
+  guarantee(!Universe::teraHeap()->is_in_h2((HeapWord *) p), "should not be in H2 the parent object field");
 
   //If obj is in H2
   //  (1) set H2 region live bit
@@ -279,6 +282,8 @@ inline void G1ConcurrentRefineOopClosure::do_oop_work(T* p) {
     // 6
     const char *name = "G1ConcurrentRefineOopClosure::do_oop_work";
     Universe::teraHeap()->mark_used_region(cast_from_oop<HeapWord*>(obj), (char *) name);
+  #else
+    Universe::teraHeap()->mark_used_region(cast_from_oop<HeapWord*>(obj));
   #endif // DBG_LOST_REGION
     return;
   }
@@ -328,14 +333,15 @@ inline void G1ScanCardClosure::do_oop_work(T* p) {
   #ifdef DBG_LOST_REGION
     // TODO: should we mark region live here? --> caused error again
     // 4
-    // Universe::teraHeap()->mark_used_region(cast_from_oop<HeapWord*>(obj));
     const char *name = "G1ScanCardClosure::do_oop_work";
     Universe::teraHeap()->mark_used_region(cast_from_oop<HeapWord*>(obj), (char *) name);
+  #else
+    Universe::teraHeap()->mark_used_region(cast_from_oop<HeapWord*>(obj));
   #endif // DBG_LOST_REGION
     return;
   }
 
-  if (!Universe::teraHeap()->is_in_h2(p))
+  if (EnableTeraHeap && !Universe::teraHeap()->is_in_h2(p))
     check_obj_during_refinement(p, obj);
   
   assert(Universe::teraHeap()->is_in_h2(p) || !_g1h->is_in_cset((HeapWord*)p),
@@ -388,16 +394,7 @@ inline void H2ToH1Closure::do_oop_work(T* p) {
   // h2->h2
   if (Universe::teraHeap()->is_in_h2(obj)) {
     Universe::teraHeap()->group_regions((HeapWord *)p, cast_from_oop<HeapWord*>(obj));
-    if (should_mark) {
-    #ifdef DBG_LOST_REGION
-      const char *name = "H2ToH1Closure::do_oop_work";
-      Universe::teraHeap()->mark_used_region(cast_from_oop<HeapWord*>(obj), (char *) name);
-    #else
-      Universe::teraHeap()->mark_used_region(cast_from_oop<HeapWord*>(obj));
-    #endif // DBG_LOST_REGION
-    }
-
-		return;	
+    return;	
   }
 
   const G1HeapRegionAttr region_attr = _g1h->region_attr(obj);
@@ -472,6 +469,8 @@ void G1ParCopyHelper::do_cld_barrier(oop new_obj) {
     // 7
     const char *name = "G1ParCopyHelper::do_cld_barrier";
     Universe::teraHeap()->mark_used_region(cast_from_oop<HeapWord*>(new_obj), (char *) name);
+  #else
+    Universe::teraHeap()->mark_used_region(cast_from_oop<HeapWord*>(new_obj));
   #endif // DBG_LOST_REGION
     return;
   }
@@ -506,13 +505,13 @@ void G1ParCopyClosure<barrier, should_mark>::do_oop_work(T* p) {
 
   oop obj = CompressedOops::decode_not_null(heap_oop);
 
+  guarantee(!Universe::teraHeap()->is_in_h2((HeapWord *) p), "should group regions!!!");
   //If obj is in H2
   //  (1) if (should_mark) set H2 region live bit
   //  (2) Fence heap traversal to H2
 #ifdef TERA_MAINTENANCE  
   if (EnableTeraHeap && Universe::teraHeap()->is_in_h2(obj)) {
     //set H2 region live bit
-    if (should_mark) {
     #ifdef DBG_LOST_REGION
       // NOTE: why only when should_mark?
       const char *name = "G1ParCopyClosure<barrier, should_mark>::do_oop_work";
@@ -520,8 +519,6 @@ void G1ParCopyClosure<barrier, should_mark>::do_oop_work(T* p) {
     #else
       Universe::teraHeap()->mark_used_region(cast_from_oop<HeapWord*>(obj));
     #endif // DBG_LOST_REGION
-    }
-
     return;
   }
 #endif

--- a/jdk17/src/hotspot/share/gc/shared/cardTable.cpp
+++ b/jdk17/src/hotspot/share/gc/shared/cardTable.cpp
@@ -563,18 +563,20 @@ void CardTable::th_write_ref_field(void *obj) {
   *card = dirty_card;
 }
 
-void CardTable::th_clean_cards(HeapWord *start, HeapWord* end) {
+void CardTable::th_clean_cards(HeapWord *start, HeapWord* end, bool free_regions) {
   assert((HeapWord*)align_down((uintptr_t)start, HeapWordSize) == start, "Unaligned start");
   assert((HeapWord*)align_up  ((uintptr_t)end,   HeapWordSize) == end,   "Unaligned end"  );
   CardValue* cur  = byte_for(start);
   CardValue* last = byte_for(end);
-      
+  size_t delta = pointer_delta(last, cur, sizeof(CardValue));
+
   // H2 card table is reserved but memory is protected for reads and
   // writes. We need to remove protection for the specific address
-  // range
-  os::protect_memory((char *) cur, (last-cur)-1, os::MEM_PROT_RW);
+  // range at the start of the JVM.
+  if (!free_regions)
+    os::protect_memory((char *) cur, delta, os::MEM_PROT_RW);
 
-  memset(cur, clean_card, (last-cur)-1);
+  memset(cur, clean_card, delta);
 }
 
 // TODO: remove
@@ -584,12 +586,7 @@ void CardTable::th_dirty_cards(HeapWord *start, HeapWord* end) {
   CardValue* cur  = byte_for(start);
   CardValue* last = byte_for(end);
       
-  // H2 card table is reserved but memory is protected for reads and
-  // writes. We need to remove protection for the specific address
-  // range
-  os::protect_memory((char *) cur, (last-cur)-1, os::MEM_PROT_RW);
-
-  memset(cur, dirty_card, (last-cur)-1);
+  memset(cur, dirty_card, pointer_delta(last, cur, sizeof(CardValue)));
 }
 
 void CardTable::th_num_dirty_cards(HeapWord *start, HeapWord* end, bool before) {

--- a/jdk17/src/hotspot/share/gc/shared/cardTable.hpp
+++ b/jdk17/src/hotspot/share/gc/shared/cardTable.hpp
@@ -253,7 +253,7 @@ public:
   virtual void invalidate(MemRegion mr);
 #ifdef TERA_CARDS
   virtual void th_write_ref_field(void *obj);
-  virtual void th_clean_cards(HeapWord *start, HeapWord *end);
+  virtual void th_clean_cards(HeapWord *start, HeapWord *end, bool free_regions = false);
   virtual void th_dirty_cards(HeapWord *start, HeapWord *end);
   virtual void th_num_dirty_cards(HeapWord *start, HeapWord *end, bool before);
 #endif //TERA_CARDS

--- a/jdk17/src/hotspot/share/gc/teraHeap/teraHeap.cpp
+++ b/jdk17/src/hotspot/share/gc/teraHeap/teraHeap.cpp
@@ -30,8 +30,13 @@ static void segv_handler(int sig, siginfo_t *si, void *arg) {
 
   fprintf(stderr, "SIGSEGV at address %p (si_code=%d)\n", addr, si->si_code);
   if (Universe::teraHeap()->is_in_h2(addr)) {
-    uint64_t region = region_containing_addr((char *)addr);
-    fprintf(stderr, "L The address is in H2 in region %lu which is used=%d\n", region, is_used(region));
+    uint64_t region_idx = region_containing_addr((char *)addr);
+    fprintf(stderr, "L The address is in H2 in region %lu which is used=%d\n", region_idx, is_used(region_idx));
+    struct region *region = get_region(region_idx);
+    fprintf(stderr, "L Region: {\n");
+    fprintf(stderr, "     - start:          %p\n", region->start_address);
+    fprintf(stderr, "     - last alloc end: %p\n", region->last_allocated_end);
+    fprintf(stderr, "  }\n");
   }
   _exit(128 + SIGSEGV);
 }
@@ -113,15 +118,6 @@ bool TeraHeap::h2_is_empty() {
 // Check if a pointer belongs to the TeraHeap.
 bool TeraHeap::is_in_h2(const void* p) {
 	const char* cp = (const char *) p;
-#ifdef DBG_LOST_REGION
-    //--- Debug v
-  if (cp >= _start_addr && cp < _stop_addr) {
-    mark_used_region(cast_from_oop<HeapWord*>(cast_to_oop(p)), (char *) "debug");
-    return true;
-  }
-  return false;
-    //--- Debug ^
-#endif // DBG_LOST_REGION
 	return cp >= _start_addr && cp < _stop_addr;
 }
 
@@ -286,27 +282,32 @@ void TeraHeap::h2_print_objects_per_region() {
 	}
 }
 
-#ifdef DBG_LOST_REGION
-#include "gc/g1/g1CollectedHeap.hpp"
-#endif // DBG_LOST_REGION
-
 // Frees all unused regions
 void TeraHeap::free_unused_regions(void) {
-  // fprintf(stderr, "[WARNING] Free is disabled!\n");
-  struct region_list *ptr = free_regions();
-  struct region_list *prev = NULL;
-  while (ptr != NULL) {
-    _start_array.th_region_reset((HeapWord*) ptr->start, (HeapWord*) ptr->end);
+	CardTable* const ct = th_card_table();
+
+  struct region_list *region = free_regions();
+  while (region != NULL) {
+    region_list* const next = region->next;
+
+    HeapWord* const region_start        = reinterpret_cast<HeapWord*>(region->region_start);
+    HeapWord* const last_alloc_start    = reinterpret_cast<HeapWord*>(region->last_allocated_start);
+    HeapWord* const last_alloc_end_excl = reinterpret_cast<HeapWord*>(region->last_allocated_end);
+
+    _start_array.th_region_reset(region_start, last_alloc_start);
+
+    // `last_alloc_end_excl` is an exclusive end (one past the last valid heap
+    // word). Convert to an inclusive end by subtracting one heap word.
+    ct->th_clean_cards(region_start, last_alloc_end_excl - 1, true /* free regions */);
 
 #ifdef DBG_PROTECT_FREE_REGIONS
-    make_region_inaccessible(ptr->start, GCId::current());
+    make_region_inaccessible(region_start, GCId::current());
 #endif // DBG_PROTECT_FREE_REGIONS
-
-    prev = ptr;
-    ptr = ptr->next;
-
-    free(prev);
+    free(region);
+    region = next;
   }
+
+  tera_stats->set_reclaimed_region_count(num_reclaimed_regions());
 }
 
 // Pop the objects that are in `_th_stack` and mark them as live
@@ -491,8 +492,24 @@ void TeraHeap::group_region_enabled(HeapWord* obj, void *obj_field) {
 	ct->th_write_ref_field(h2_obj_field);
 }
 
-// Groups the region of obj with the previously enabled region of a thread (multi-threaded)
-void TeraHeap::thread_group_region_enabled(uint thread_id, HeapWord *obj, void *obj_field) {
+// Check and record metadata for references involving a cross-heap edge (H1 <->
+// H2) and/or a cross-H2-region edge during H1->H2 relocation.
+//
+// This helper is only meaningful while the current thread is processing an
+// object that has an H2 destination (h2_addr_arr[thread_id] != NULL). Otherwise
+// it is a no-op.
+//
+// Behavior:
+//  - If the referenced object (`obj`) is already in H2, record a
+//  cross-H2-region dependency between the destination H2 region of the
+//  relocating object and the H2 region containing `obj` (via group_regions()).
+//  - If the referenced object is in H1, compute the corresponding field slot in
+//    the H2 copy and mark the H2 card table for that slot as dirty, so the H2
+//    side will rescan/remember this backward (H2->H1) reference.
+//  - In some paths (e.g., backward pointer popped from th_adjust_stack where
+//    h1_addr_arr[thread_id] == NULL), do nothing because the card is already
+//    dirty from a prior GC phase.
+void TeraHeap::check_for_cross_heap_cross_h2_region_ref(uint thread_id, HeapWord *obj, void *obj_field) {
 	// Object is not going to be moved to TeraHeap
 	if (h2_addr_arr[thread_id] == NULL) 
 		return;
@@ -510,9 +527,7 @@ void TeraHeap::thread_group_region_enabled(uint thread_id, HeapWord *obj, void *
 
   // Mark the H2 card table as dirty if obj is in H1 (backward
   // reference)
-	BarrierSet* bs = BarrierSet::barrier_set();
-	CardTableBarrierSet* ctbs = barrier_set_cast<CardTableBarrierSet>(bs);
-	CardTable* ct = ctbs->th_card_table();
+	CardTable* const ct = th_card_table();
 
 	size_t diff =  (HeapWord *)obj_field - h1_addr_arr[thread_id];
 	assert(diff > 0 && (diff <= (uint64_t) cast_to_oop(h1_addr_arr[thread_id])->size()),
@@ -622,7 +637,16 @@ TeraStatistics* TeraHeap::get_tera_stats() {
 }
 
 // Make every card of H2 dirty
-void TeraHeap::dirty_all_cards(CardTable *th_card_table) {
-  th_card_table->th_dirty_cards((HeapWord*) h2_start_addr(), (HeapWord*) h2_end_addr() - 1);
-  fprintf(stderr, "All cards are dirty\n");
+void TeraHeap::dirty_all_cards() {
+  HeapWord* const start = reinterpret_cast<HeapWord*>(_start_addr);
+  HeapWord* const end_excl = reinterpret_cast<HeapWord*>(_stop_addr);
+
+  // Convert exclusive end to inclusive end.
+  th_card_table()->th_dirty_cards(start, end_excl - 1);
+}
+
+CardTable* TeraHeap::th_card_table() {
+  BarrierSet* bs = BarrierSet::barrier_set();
+  CardTableBarrierSet* ctbs = barrier_set_cast<CardTableBarrierSet>(bs);
+  return ctbs->th_card_table();
 }

--- a/jdk17/src/hotspot/share/gc/teraHeap/teraHeap.hpp
+++ b/jdk17/src/hotspot/share/gc/teraHeap/teraHeap.hpp
@@ -53,6 +53,7 @@ private:
                           // to H2 if it has back ptrs
                           // to H1
 
+  static CardTable* th_card_table(void);
 public:
   // Constructor
   TeraHeap();
@@ -187,8 +188,10 @@ public:
   // Groups the region of obj with the previously enabled region (single-threaded)
   void group_region_enabled(HeapWord *obj, void *obj_field);
 
-  // Groups the region of obj with the previously enabled region of a thread (multi-threaded)
-  void thread_group_region_enabled(uint thread_id, HeapWord *obj, void *obj_field);
+  // If the current thread is relocating an object to H2, record cross-heap / cross-H2-region
+  // reference metadata (region dependency or H2 card marking) for the reference slot `obj_field`.
+  // No-op if relocation context is not active.
+  void check_for_cross_heap_cross_h2_region_ref(uint thread_id, HeapWord *obj, void *obj_field);
 
   // Frees all unused regions
   void free_unused_regions(void);
@@ -266,7 +269,7 @@ public:
   // Utility functions
   // ------------------
   // Make every card of H2 dirty (used for debugging)
-  void dirty_all_cards(CardTable *th_card_table);
+  void dirty_all_cards();
   // ------------------
 };
 

--- a/jdk17/src/hotspot/share/gc/teraHeap/teraStatistics.cpp
+++ b/jdk17/src/hotspot/share/gc/teraHeap/teraStatistics.cpp
@@ -74,6 +74,8 @@ TeraStatistics::TeraStatistics() {
   thlog_or_tty->flush();
 #endif // RUSAGE_MUTATOR
 
+  reclaimed_regions_count = 0;
+
   reset_counters();
 }
 
@@ -155,6 +157,7 @@ void TeraStatistics::print_gc_stats() {
     thlog_or_tty->print_cr("[FULL] | BACK_PTRS = %lu", backward_ref);
     thlog_or_tty->print_cr("[FULL] | TOTAL_OBJECTS  = %lu", total_objects_moved);
     thlog_or_tty->print_cr("[FULL] | TOTAL_OBJECTS_SIZE = %lu", total_objects_size);
+    thlog_or_tty->print_cr("[FULL] | RECLAIMED_REGIONS = %u", reclaimed_regions_count);
     thlog_or_tty->print_cr("[FULL] | TIME_SCAN_H2_CT %.3lf ms", h2_card_table_scan_time_ms);
     thlog_or_tty->print_cr("[FULL] | TIME_TO_ALLOC_H2 %.3lf ms", h2_allocate_ms);
     thlog_or_tty->print_cr("[FULL] | TIME_TO_COPY_H2 %.3lf ms (accurate for single threaded)", h2_copy_ms);
@@ -162,6 +165,7 @@ void TeraStatistics::print_gc_stats() {
     // Young
     thlog_or_tty->print_cr("[YOUNG] | BACK_PTRS = %lu", backward_ref);
     thlog_or_tty->print_cr("[YOUNG] | TIME_SCAN_H2_CT %.3lf ms", h2_card_table_scan_time_ms);
+    thlog_or_tty->print_cr("[YOUNG] | RECLAIMED_REGIONS = %u", reclaimed_regions_count);
   }
 
   thlog_or_tty->flush();
@@ -171,6 +175,7 @@ void TeraStatistics::print_gc_stats() {
   backward_ref = 0;
   _is_mixed_gc = false;
   _is_full_gc = false;
+  reclaimed_regions_count = 0;
 }
 
 double TeraStatistics::get_max_thr_time_alloc_h2() {

--- a/jdk17/src/hotspot/share/gc/teraHeap/teraStatistics.hpp
+++ b/jdk17/src/hotspot/share/gc/teraHeap/teraStatistics.hpp
@@ -73,6 +73,8 @@ private:
   std::map<oop, int> fwd_ref_histo;
 #endif
 
+  uint reclaimed_regions_count;
+
 public:
 
   TeraStatistics();
@@ -219,6 +221,10 @@ public:
   // Print the histogram
   void h2_print_fwd_ref_stat();
 #endif
+
+  void set_reclaimed_region_count(uint num_reclaimed_regions) {
+    reclaimed_regions_count = num_reclaimed_regions;
+  }
 
 private:
 

--- a/jdk17/src/hotspot/share/utilities/vmError.cpp
+++ b/jdk17/src/hotspot/share/utilities/vmError.cpp
@@ -1318,25 +1318,8 @@ void VMError::report_and_die(Thread* thread, unsigned int sig, address pc, void*
   va_end(detail_args);
 }
 
-#ifdef DBG_LOST_REGION
-#include <regions.h>
-#endif // DBG_LOST_REGION
-
 void VMError::report_and_die(Thread* thread, unsigned int sig, address pc, void* siginfo, void* context)
 {
-#ifdef DBG_LOST_REGION
-  void *addr = ((siginfo_t *)siginfo)->si_addr;
-  fprintf(stderr, "SIGSEGV at address %p (si_code=%d)\n", addr, ((siginfo_t *)siginfo)->si_code);
-  if (Universe::teraHeap()->is_in_h2(addr)) {
-    uint64_t region_idx = region_containing_addr((char *)addr);
-    struct region *region = get_region(region_idx);
-    fprintf(stderr, "L The address is in H2 in region %lu which is used=%d\n", region_idx, is_used(region_idx));
-    fprintf(stderr, "L Region: {\n");
-    fprintf(stderr, "     - start:          %p\n", region->start_address);
-    fprintf(stderr, "     - last alloc end: %p\n", region->last_allocated_end);
-    fprintf(stderr, "  }\n");
-  }
-#endif // DBG_LOST_REGION
   report_and_die(thread, sig, pc, siginfo, context, "%s", "");
 }
 

--- a/tests/conf.sh
+++ b/tests/conf.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-H2_REGION_SIZE=$((256 * 1024 * 1024))
+H2_REGION_SIZE=$((32 * 1024 * 1024))
 H2_CARD_SEGMENT_SIZE=$((8 * 1024))
 STRIPE_SIZE=$(( H2_REGION_SIZE / H2_CARD_SEGMENT_SIZE ))
 H2_SIZE_IN_BYTES=$(echo "700 * 1024 * 1024 * 1024" | bc)
@@ -34,6 +34,8 @@ ONLY_EVAC_TESTS=(
   "Array_List_String"
   "Test_CM_WeakRef"
   "Test_H2_CM_YoungInterrupt"
+  "Test_H2_FreePath_CM_YoungStorm"
+  "Test_H2_DependencyList_Race"
 )
 
 # These tests exist only in full benchmark suite

--- a/tests/g1_evacuations/java/Makefile
+++ b/tests/g1_evacuations/java/Makefile
@@ -23,7 +23,8 @@ TARGET = $(addprefix bin/, \
 				 MultiList.class Simple_Lambda.class Extend_Lambda.class \
 				 Test_Reflection.class Test_Reference.class HashMap.class Rehashing.class \
 				 Clone.class Groupping.class MultiHashMap.class Test_WeakHashMap.class \
-				 ClassInstance.class Test_CM_WeakRef.class Test_H2_CM_YoungInterrupt.class)
+				 ClassInstance.class Test_CM_WeakRef.class Test_H2_CM_YoungInterrupt.class \
+				 Test_H2_FreePath_CM_YoungStorm.class Test_H2_DependencyList_Race.class)
 
 .PHONY: header
 	   

--- a/tests/g1_evacuations/java/Test_H2_DependencyList_Race.java
+++ b/tests/g1_evacuations/java/Test_H2_DependencyList_Race.java
@@ -1,0 +1,264 @@
+import java.lang.reflect.Field;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Stress the race:
+ *   - One thread repeatedly triggers CM + GCs (causing mark_used(seg1) and traversal of seg1 deps).
+ *   - Another thread rapidly creates NEW H2 cross-region edges seg1 -> seg2 by mutating fields
+ *     (which should invoke references(seg1, seg2) in your runtime), and then quickly drops
+ *     other references so seg2 is a reclaim candidate unless it is marked used via propagation.
+ *
+ * Detection strategy:
+ *   - Maintain a stable H2 "anchor" object in a never-dropped H2 root located in a fixed H2 region (seg1).
+ *   - Continually set anchor.ref = target where target is placed in varying H2 regions (seg2 varies).
+ *   - After GC activity, verify that anchor.ref is still a valid, touchable object (and its backing array can be read).
+ *   - If the dependency insertion races with seg1 used marking and propagation is missed, seg2 can be reclaimed
+ *     even though anchor still points to it -> crash, corruption, or verifier throws.
+ *
+ * Notes:
+ *   - This test is intentionally aggressive; tune defaults as needed.
+ *   - It assumes your H2 region placement depends on (a2, a3) tags applied to roots.
+ */
+public class Test_H2_DependencyList_Race {
+
+  private static final sun.misc.Unsafe U;
+  static {
+    try {
+      Field f = sun.misc.Unsafe.class.getDeclaredField("theUnsafe");
+      f.setAccessible(true);
+      U = (sun.misc.Unsafe) f.get(null);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  // The object that resides in H2 and is used as the "source" (seg1).
+  // We will constantly mutate ref to point to objects in other H2 regions (seg2).
+  static final class Anchor {
+    volatile Object ref;      // mutated frequently to create seg1 -> seg2 edges
+    final byte[] pad;         // touchable memory to keep it "real"
+
+    Anchor(int padKb) {
+      this.pad = new byte[padKb * 1024];
+      pad[0] = 1;
+      pad[pad.length / 2] = 2;
+      pad[pad.length - 1] = 3;
+    }
+
+    long touch() {
+      long acc = 0;
+      acc ^= (pad[0] & 0xFFL);
+      acc ^= (pad[pad.length / 2] & 0xFFL) << 8;
+      acc ^= (pad[pad.length - 1] & 0xFFL) << 16;
+      return acc;
+    }
+  }
+
+  // Target objects placed in many other H2 regions.
+  static final class Target {
+    final int id;
+    final long cookie;
+    final byte[] blob;
+
+    Target(int id, int blobKb) {
+      this.id = id;
+      this.cookie = ((long) id << 32) ^ 0xC6A4A7935BD1E995L;
+      this.blob = new byte[blobKb * 1024];
+      // touch to commit
+      if (blob.length > 0) {
+        blob[0] = (byte) id;
+        blob[blob.length / 2] = (byte) (id ^ 0x5A);
+        blob[blob.length - 1] = (byte) (id ^ 0x33);
+      }
+    }
+
+    long touch() {
+      int len = blob.length;
+      long acc = cookie ^ id;
+      if (len > 0) {
+        acc ^= (blob[0] & 0xFFL);
+        acc ^= (blob[len >>> 1] & 0xFFL) << 8;
+        acc ^= (blob[len - 1] & 0xFFL) << 16;
+      }
+      return acc;
+    }
+  }
+
+  // Fixed H2 "seg1" root: contains exactly one Anchor that never gets dropped.
+  private static Object[] makeAnchorRoot(int padKb, int segStripe, int segGroup) {
+    Object[] root = new Object[1];
+    U.h2TagAndMoveRoot(root, segStripe, segGroup);
+    root[0] = new Anchor(padKb);
+    return root;
+  }
+
+  // A pool of roots used only to place Target objects in many different H2 regions (vary seg2).
+  private static Object[][] makeTargetRoots(int numRoots, int rootLen) {
+    Object[][] roots = new Object[numRoots][];
+    for (int i = 0; i < numRoots; i++) {
+      Object[] r = new Object[rootLen];
+
+      int a2 = i & 0xF;
+      int a3 = (i >>> 4) & 0xF;
+      U.h2TagAndMoveRoot(r, a2, a3);
+
+      roots[i] = r;
+    }
+    return roots;
+  }
+
+  private static long verifyAnchor(Anchor a) {
+    long acc = a.touch();
+    Object o = a.ref;
+    if (o == null) return acc;
+
+    if (!(o instanceof Target)) {
+      throw new AssertionError("Anchor.ref unexpected type: " + o.getClass());
+    }
+    Target t = (Target) o;
+    acc ^= t.touch();
+
+    // Extra deref/reads to catch stale freed memory patterns earlier
+    byte[] b = t.blob;
+    if (b.length > 0) {
+      acc ^= (b[0] & 0xFFL) << 24;
+      acc ^= (b[b.length / 2] & 0xFFL) << 32;
+      acc ^= (b[b.length - 1] & 0xFFL) << 40;
+    }
+
+    return acc;
+  }
+
+  public static void main(String[] args) throws Exception {
+    // Knobs (defaults are aggressive)
+    final int RUN_SECS          = (args.length > 0) ? Integer.parseInt(args[0]) : 60;
+    final int TARGET_ROOTS      = (args.length > 1) ? Integer.parseInt(args[1]) : 256;
+    final int TARGET_ROOT_LEN   = (args.length > 2) ? Integer.parseInt(args[2]) : 1024;
+    final int TARGET_BLOB_KB    = (args.length > 3) ? Integer.parseInt(args[3]) : 8;
+    final int ANCHOR_PAD_KB     = (args.length > 4) ? Integer.parseInt(args[4]) : 64;
+
+    final int STORES_PER_BURST  = (args.length > 5) ? Integer.parseInt(args[5]) : 200_000;
+    final int BURSTS_PER_CM     = (args.length > 6) ? Integer.parseInt(args[6]) : 4;
+
+    final int NULL_OUT_RATE     = (args.length > 7) ? Integer.parseInt(args[7]) : 8;   // 1/N store ops also null-out random target slots
+    final int YOUNG_GCS_PER_CM  = (args.length > 8) ? Integer.parseInt(args[8]) : 20_000;
+    final int FULL_GC_EVERY     = (args.length > 9) ? Integer.parseInt(args[9]) : 2;   // every N CM cycles do GC.gc()
+
+    System.out.println("RUN_SECS=" + RUN_SECS +
+        " TARGET_ROOTS=" + TARGET_ROOTS +
+        " TARGET_ROOT_LEN=" + TARGET_ROOT_LEN +
+        " TARGET_BLOB_KB=" + TARGET_BLOB_KB +
+        " ANCHOR_PAD_KB=" + ANCHOR_PAD_KB +
+        " STORES_PER_BURST=" + STORES_PER_BURST +
+        " BURSTS_PER_CM=" + BURSTS_PER_CM +
+        " NULL_OUT_RATE=1/" + NULL_OUT_RATE +
+        " YOUNG_GCS_PER_CM=" + YOUNG_GCS_PER_CM +
+        " FULL_GC_EVERY=" + FULL_GC_EVERY);
+
+    // Place anchor in a fixed H2 region (seg1).
+    Object[] anchorRoot = makeAnchorRoot(ANCHOR_PAD_KB, 0xE, 0xE);
+    Anchor anchor = (Anchor) anchorRoot[0];
+
+    // Roots used to place targets in many other H2 regions (seg2 varies).
+    Object[][] targetRoots = makeTargetRoots(TARGET_ROOTS, TARGET_ROOT_LEN);
+
+    // Reduce noise
+    GC.move_to_old();
+    GC.gc();
+
+    final AtomicBoolean stop = new AtomicBoolean(false);
+    final CountDownLatch start = new CountDownLatch(1);
+
+    // Thread 1: create massive numbers of NEW seg1->seg2 edges by mutating anchor.ref.
+    Thread mutator = new Thread(() -> {
+      try { start.await(); } catch (InterruptedException ignored) {}
+      ThreadLocalRandom rnd = ThreadLocalRandom.current();
+      int id = 1;
+
+      while (!stop.get()) {
+        for (int burst = 0; burst < BURSTS_PER_CM && !stop.get(); burst++) {
+          for (int i = 0; i < STORES_PER_BURST; i++) {
+            // Pick a target root (seg2 varies) and slot
+            Object[] r = targetRoots[rnd.nextInt(targetRoots.length)];
+            int idx = rnd.nextInt(r.length);
+
+            // Create a brand new Target and install it in that seg2 root slot
+            Target t = new Target(id++, TARGET_BLOB_KB);
+            r[idx] = t;
+
+            // Create the critical edge: seg1 (anchor) -> seg2 (t)
+            // This should trigger references(seg1, seg2) in your runtime.
+            anchor.ref = t;
+
+            // Occasionally null-out some target slots to make seg2 regions reclaim candidates
+            if ((i % NULL_OUT_RATE) == 0) {
+              Object[] rr = targetRoots[rnd.nextInt(targetRoots.length)];
+              rr[rnd.nextInt(rr.length)] = null;
+            }
+
+            // Also occasionally drop the edge itself to churn dependencies
+            if ((i & 0x3FFF) == 0) {
+              anchor.ref = null;
+            }
+          }
+        }
+      }
+    }, "h2-deps-mutator");
+
+    // Thread 2: repeatedly trigger CM + lots of young GCs + occasional full GC.
+    // The goal is to maximize opportunities where seg1 is marked used and dependency lists are traversed
+    // concurrently with the insertion of new dependencies.
+    Thread gcDriver = new Thread(() -> {
+      try { start.await(); } catch (InterruptedException ignored) {}
+      long end = System.currentTimeMillis() + RUN_SECS * 1000L;
+      int cm = 0;
+
+      while (!stop.get() && System.currentTimeMillis() < end) {
+        GC.cm_start();
+        GC.young_gc(); // interrupt quickly
+
+        for (int i = 0; i < YOUNG_GCS_PER_CM; i++) {
+          GC.young_gc();
+          if ((i & 0x1FFF) == 0) {
+            // Touch the anchor frequently to keep it hot/live and to force loads through it.
+            verifyAnchor(anchor);
+          }
+        }
+
+        GC.wait_cm();
+
+        if (FULL_GC_EVERY > 0 && (cm % FULL_GC_EVERY) == 0) {
+          GC.gc();
+        }
+        cm++;
+
+        // Strong check every CM cycle: if anchor.ref points somewhere, it must be safe to touch.
+        // If a dependent region was falsely reclaimed, this often crashes or throws here.
+        long v = verifyAnchor(anchor);
+        if ((cm % 10) == 0) {
+          System.out.println("gcDriver: cm=" + cm + " verify=" + v);
+        }
+      }
+
+      stop.set(true);
+    }, "gc-driver");
+
+    mutator.setDaemon(true);
+    gcDriver.setDaemon(true);
+    mutator.start();
+    gcDriver.start();
+    start.countDown();
+
+    // Wait until gcDriver ends the run
+    while (!stop.get()) {
+      Thread.sleep(100);
+    }
+
+    // Final push
+    for (int i = 0; i < 5; i++) GC.gc();
+    long fin = verifyAnchor(anchor);
+    System.out.println("Done. final verify=" + fin);
+  }
+}

--- a/tests/g1_evacuations/java/Test_H2_FreePath_CM_YoungStorm.java
+++ b/tests/g1_evacuations/java/Test_H2_FreePath_CM_YoungStorm.java
@@ -1,0 +1,500 @@
+import java.lang.reflect.Field;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Stress test: H2 reclamation ("free path") during concurrent marking + young-GC storms,
+ * with *explicit* verification that still-live H2 regions were not falsely reclaimed.
+ *
+ * Key stressors:
+ *  1) Many H2 roots, placed across different H2 regions via Unsafe.h2TagAndMoveRoot(root, a2, a3).
+ *  2) Each H2 root contains many H2Payload objects (H2-resident).
+ *  3) Some H2Payload objects point to humongous objects allocated in H1 (normal Java heap):
+ *       H2 -> H1(humongous) edges.
+ *  4) During CM, we:
+ *     - null out many H2 slots (creating free candidates inside H2)
+ *     - drop whole H2 roots (whole H2 regions become free candidates)
+ *     - storm young GCs (interrupt CM repeatedly)
+ *     - mutate H2 contents and H2->H1 edges (exercise barriers / cards / remsets)
+ *
+ * Verification:
+ *  A) Structural: traverse all remaining H2 roots and validate fingerprints.
+ *  B) Active-touch H2: read multiple offsets from H2Payload.blob arrays (backing memory touch).
+ *  C) Active-touch H1 humongous: via H2->H1 edges, touch humongous arrays repeatedly.
+ *  D) Sentinels: keep a stable set of H2 payloads (and their H1 humongous targets) in a
+ *     never-dropped H2 root; its accumulator must remain stable across cycles.
+ *
+ * Assumes harness provides:
+ *  - GC.cm_start(), GC.wait_cm(), GC.young_gc(), GC.move_to_old(), GC.gc()
+ *  - sun.misc.Unsafe.h2TagAndMoveRoot(Object root, int a2, int a3)
+ */
+public class Test_H2_FreePath_CM_YoungStorm {
+
+  private static final sun.misc.Unsafe U;
+  static {
+    try {
+      Field f = sun.misc.Unsafe.class.getDeclaredField("theUnsafe");
+      f.setAccessible(true);
+      U = (sun.misc.Unsafe) f.get(null);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  // H2-resident payload: has an internal blob (H2 memory) and optional reference to H1 humongous.
+  static final class H2Payload {
+    final int id;
+    final long cookie;
+    final byte[] blob;     // intended to live in H2 (reachable from H2 root)
+    Object maybeRef;       // used for (a) internal refs (H2->H2) or (b) H2->H1 humongous
+
+    H2Payload(int id, int blobKb) {
+      this.id = id;
+      this.cookie = ((long) id << 32) ^ 0x9E3779B97F4A7C15L;
+      this.blob = new byte[blobKb * 1024];
+
+      // Touch to commit and create stable signal.
+      if (blob.length > 0) {
+        blob[0] = (byte) id;
+        blob[blob.length / 2] = (byte) (id ^ 0x5A);
+        blob[blob.length - 1] = (byte) (id ^ 0x33);
+      }
+    }
+
+    long fingerprint() {
+      long s = cookie;
+      if (blob.length > 0) {
+        s ^= blob[0];
+        s ^= blob[blob.length / 2];
+        s ^= blob[blob.length - 1];
+      }
+      return s;
+    }
+  }
+
+  // H1 humongous object wrapper (allocated in normal Java heap = H1).
+  // Under G1, if huge >= ~1/2 region size, it becomes "humongous".
+  static final class H1Humongous {
+    final int id;
+    final long cookie;
+    final byte[] huge;
+
+    H1Humongous(int id, int bytes) {
+      this.id = id;
+      this.cookie = ((long) id << 32) ^ 0xD6E8FEB86659FD93L;
+      this.huge = new byte[bytes];
+
+      // Touch multiple offsets to commit pages and make reads meaningful.
+      huge[0] = (byte) id;
+      huge[huge.length >>> 2] = (byte) (id ^ 0xA5);
+      huge[huge.length >>> 1] = (byte) (id ^ 0x3C);
+      huge[(huge.length * 3) >>> 2] = (byte) (id ^ 0x7E);
+      huge[huge.length - 1] = (byte) (id ^ 0x19);
+    }
+
+    long touch() {
+      int len = huge.length;
+      long acc = cookie ^ ((long) id << 17);
+      acc ^= (huge[0] & 0xFFL);
+      acc ^= (huge[len >>> 2] & 0xFFL) << 8;
+      acc ^= (huge[len >>> 1] & 0xFFL) << 16;
+      acc ^= (huge[(len * 3) >>> 2] & 0xFFL) << 24;
+      acc ^= (huge[len - 1] & 0xFFL) << 32;
+      return acc;
+    }
+  }
+
+  // Young object that points to an H2 object (young -> H2 edge).
+  static final class YoungToH2 {
+    final Object ref;
+    final int tag;
+    YoungToH2(Object ref, int tag) { this.ref = ref; this.tag = tag; }
+  }
+
+  // -------- Verification helpers --------
+
+  // Touch backing arrays for H2 payload (stronger than fingerprint alone).
+  private static long touchH2PayloadBacking(H2Payload p) {
+    byte[] b = p.blob;
+    if (b == null || b.length == 0) return p.cookie;
+
+    int len = b.length;
+    int o0 = 0;
+    int o1 = len >>> 2;
+    int o2 = len >>> 1;
+    int o3 = (len * 3) >>> 2;
+    int o4 = len - 1;
+
+    long acc = p.cookie ^ (long) p.id;
+    acc ^= (b[o0] & 0xFFL);
+    acc ^= (b[o1] & 0xFFL) << 8;
+    acc ^= (b[o2] & 0xFFL) << 16;
+    acc ^= (b[o3] & 0xFFL) << 24;
+    acc ^= (b[o4] & 0xFFL) << 32;
+
+    return acc;
+  }
+
+  // Verify + touch everything reachable from live H2 roots.
+  // This is the "main" verifier: it will dereference H2 backing arrays and H1 humongous arrays.
+  private static long verifyAndTouchAll(Object[][] roots) {
+    long acc = 0;
+    for (Object[] r : roots) {
+      if (r == null) continue;
+      for (Object o : r) {
+        if (!(o instanceof H2Payload)) {
+          if (o == null) continue;
+          throw new AssertionError("Unexpected object in H2 root: " + o.getClass());
+        }
+        H2Payload p = (H2Payload) o;
+
+        acc ^= p.fingerprint();
+        acc ^= touchH2PayloadBacking(p);
+
+        Object mr = p.maybeRef;
+        if (mr instanceof H2Payload) {
+          // H2 -> H2 internal edge: touch the target as well.
+          H2Payload q = (H2Payload) mr;
+          acc ^= q.fingerprint();
+          acc ^= touchH2PayloadBacking(q);
+        } else if (mr instanceof H1Humongous) {
+          // H2 -> H1(humongous) edge: touch humongous backing array
+          acc ^= ((H1Humongous) mr).touch();
+        } else if (mr != null) {
+          // If you intentionally store other types, adjust here.
+          acc ^= mr.hashCode();
+        }
+      }
+    }
+    return acc;
+  }
+
+  // Sample-touch: pick random live H2Payloads and touch their backing arrays (fast, probabilistic).
+  private static long sampleTouchLiveH2(Object[][] roots, int samples, ThreadLocalRandom rnd) {
+    long acc = 0;
+    int taken = 0;
+
+    int attempts = samples * 10;
+    while (taken < samples && attempts-- > 0) {
+      Object[] r = roots[rnd.nextInt(roots.length)];
+      if (r == null) continue;
+
+      Object o = r[rnd.nextInt(r.length)];
+      if (!(o instanceof H2Payload)) continue;
+
+      H2Payload p = (H2Payload) o;
+      acc ^= touchH2PayloadBacking(p);
+
+      Object mr = p.maybeRef;
+      if (mr instanceof H1Humongous) acc ^= ((H1Humongous) mr).touch();
+
+      taken++;
+    }
+
+    if (taken < samples) {
+      System.out.println("sampleTouchLiveH2: only sampled " + taken + "/" + samples + " live objects");
+    }
+
+    return acc;
+  }
+
+  // Create a never-dropped H2 root that holds stable sentinels.
+  // We store both the H2Payload and (if present) its H1Humongous ref, so both are exercised.
+  private static Object[] makeSentinelRoot(Object[][] roots, int sentinelCount, ThreadLocalRandom rnd) {
+    Object[] sentinelRoot = new Object[sentinelCount * 2];
+    U.h2TagAndMoveRoot(sentinelRoot, 0xE, 0xE);
+
+    int s = 0;
+    int attempts = sentinelCount * 100;
+    while (s < sentinelCount && attempts-- > 0) {
+      Object[] r = roots[rnd.nextInt(roots.length)];
+      if (r == null) continue;
+
+      Object o = r[rnd.nextInt(r.length)];
+      if (!(o instanceof H2Payload)) continue;
+
+      H2Payload p = (H2Payload) o;
+      sentinelRoot[s * 2] = p;
+      sentinelRoot[s * 2 + 1] = p.maybeRef; // may be null / H1Humongous / H2Payload
+      s++;
+    }
+
+    if (s < sentinelCount) {
+      System.out.println("makeSentinelRoot: only captured " + s + "/" + sentinelCount + " sentinels");
+    } else {
+      System.out.println("Captured " + s + " sentinels");
+    }
+
+    return sentinelRoot;
+  }
+
+  private static long touchSentinels(Object[] sentinelRoot) {
+    long acc = 0;
+    for (Object o : sentinelRoot) {
+      if (o == null) continue;
+
+      if (o instanceof H2Payload) {
+        H2Payload p = (H2Payload) o;
+        acc ^= p.fingerprint();
+        acc ^= touchH2PayloadBacking(p);
+      } else if (o instanceof H1Humongous) {
+        acc ^= ((H1Humongous) o).touch();
+      } else {
+        acc ^= o.hashCode();
+      }
+    }
+    return acc;
+  }
+
+  // -------- Allocation helpers --------
+
+  private static H1Humongous newHumongousH1(int id, int minMb, int maxMb, ThreadLocalRandom rnd) {
+    int mb = rnd.nextInt(minMb, maxMb + 1);
+    int bytes = mb * 1024 * 1024;
+    return new H1Humongous(id, bytes);
+  }
+
+  public static void main(String[] args) throws Exception {
+    // Core knobs
+    final int CYCLES              = (args.length > 0) ? Integer.parseInt(args[0]) : 20;
+    final int NUM_ROOTS           = (args.length > 1) ? Integer.parseInt(args[1]) : 128;
+    final int ROOT_LEN            = (args.length > 2) ? Integer.parseInt(args[2]) : 64_000;
+    final int BLOB_KB             = (args.length > 3) ? Integer.parseInt(args[3]) : 4;
+    final int YOUNG_GC_STORM      = (args.length > 4) ? Integer.parseInt(args[4]) : 30_000;
+    final int DROP_ROOT_EVERY     = (args.length > 5) ? Integer.parseInt(args[5]) : 2;        // cycles
+    final int NULL_SLOTS_PER_CYCLE= (args.length > 6) ? Integer.parseInt(args[6]) : 2_000_000;
+
+    // Verification knobs
+    final int TOUCH_SAMPLES_PER_CYCLE = (args.length > 7) ? Integer.parseInt(args[7]) : 50_000;
+    final int SENTINEL_COUNT          = (args.length > 8) ? Integer.parseInt(args[8]) : 256;
+
+    // H2 -> H1(humongous) knobs
+    final int H2_TO_H1_HUM_EVERY   = (args.length > 9)  ? Integer.parseInt(args[9])  : 512; // 1 edge per N payloads
+    final int H1_HUM_MIN_MB        = (args.length > 10) ? Integer.parseInt(args[10]) : 2;
+    final int H1_HUM_MAX_MB        = (args.length > 11) ? Integer.parseInt(args[11]) : 32;
+
+    // Mutation knobs (keep humongous mutation rare; it's expensive)
+    final int HUMONGOUS_MUTATE_MASK = (args.length > 12) ? Integer.parseInt(args[12]) : 0x7FFF; // every ~32768 iterations
+    final int EDGE_MUTATE_MASK      = (args.length > 13) ? Integer.parseInt(args[13]) : 0x1FFF; // every ~8192 iterations
+
+    System.out.println("Init: CYCLES=" + CYCLES +
+        " NUM_ROOTS=" + NUM_ROOTS +
+        " ROOT_LEN=" + ROOT_LEN +
+        " BLOB_KB=" + BLOB_KB +
+        " YOUNG_GC_STORM=" + YOUNG_GC_STORM +
+        " DROP_ROOT_EVERY=" + DROP_ROOT_EVERY +
+        " NULL_SLOTS_PER_CYCLE=" + NULL_SLOTS_PER_CYCLE);
+    System.out.println("Verify: TOUCH_SAMPLES_PER_CYCLE=" + TOUCH_SAMPLES_PER_CYCLE +
+        " SENTINEL_COUNT=" + SENTINEL_COUNT);
+    System.out.println("Edges: H2_TO_H1_HUM_EVERY=" + H2_TO_H1_HUM_EVERY +
+        " H1_HUM_MIN_MB=" + H1_HUM_MIN_MB +
+        " H1_HUM_MAX_MB=" + H1_HUM_MAX_MB);
+
+    Object[][] roots = new Object[NUM_ROOTS][];
+    long id = 1;
+    ThreadLocalRandom rnd = ThreadLocalRandom.current();
+
+    System.out.println("Initializing H2 roots...");
+    for (int i = 0; i < NUM_ROOTS; i++) {
+      Object[] r = new Object[ROOT_LEN];
+
+      // Vary H2 placement identifiers.
+      int a2 = i & 0xF;          // stripes
+      int a3 = (i >>> 4) & 0xF;  // groups
+      U.h2TagAndMoveRoot(r, a2, a3);
+
+      for (int j = 0; j < ROOT_LEN; j++) {
+        H2Payload p = new H2Payload((int) (id++), BLOB_KB);
+
+        // Some internal H2->H2 refs to stress scanning.
+        if ((j & 0x7) == 0 && j > 0) p.maybeRef = r[j - 1];
+
+        // Some H2 -> H1(humongous) edges.
+        // (Overwrite maybeRef sometimes: that's fine; we want a mix of H2->H2 and H2->H1.)
+        if (H2_TO_H1_HUM_EVERY > 0 && (j % H2_TO_H1_HUM_EVERY) == 0) {
+          p.maybeRef = newHumongousH1((int) (id++), H1_HUM_MIN_MB, H1_HUM_MAX_MB, rnd);
+        }
+
+        r[j] = p;
+      }
+
+      roots[i] = r;
+    }
+
+    // Reduce noise.
+    GC.move_to_old();
+    GC.gc();
+
+    // Background threads
+    final AtomicBoolean stop = new AtomicBoolean(false);
+    final CountDownLatch start = new CountDownLatch(1);
+
+    Thread youngEdgeCreator = new Thread(() -> {
+      try { start.await(); } catch (InterruptedException ignored) {}
+      ThreadLocalRandom r = ThreadLocalRandom.current();
+
+      // Keep bounded set alive so young->H2 edges persist.
+      YoungToH2[] keep = new YoungToH2[1 << 16];
+      int k = 0;
+
+      while (!stop.get()) {
+        Object[] rr = roots[r.nextInt(roots.length)];
+        if (rr != null) {
+          Object target = rr[r.nextInt(rr.length)];
+          if (target != null) {
+            keep[k++ & (keep.length - 1)] = new YoungToH2(target, k);
+          }
+        }
+
+        // Allocation pressure to trigger young GCs naturally too.
+        byte[] junk = new byte[32 * 1024];
+        junk[0] = 1;
+      }
+    }, "young->H2-edge-creator");
+
+    Thread allocator = new Thread(() -> {
+      try { start.await(); } catch (InterruptedException ignored) {}
+      Object[] keep = new Object[1 << 18];
+      int idx = 0;
+      while (!stop.get()) {
+        for (int i = 0; i < 4000; i++) {
+          byte[] a = new byte[(i & 1) == 0 ? 64 * 1024 : 128 * 1024];
+          keep[idx++ & (keep.length - 1)] = a;
+        }
+        Thread.yield();
+      }
+    }, "allocator");
+
+    youngEdgeCreator.setDaemon(true);
+    allocator.setDaemon(true);
+    youngEdgeCreator.start();
+    allocator.start();
+    start.countDown();
+
+    // Sentinels: never drop this root. It holds references into H2 and to some H1 humongous targets.
+    Object[] sentinelRoot = makeSentinelRoot(roots, SENTINEL_COUNT, rnd);
+    long sentinelBaseline = touchSentinels(sentinelRoot);
+
+    // Baseline verification/touch.
+    long baseline = verifyAndTouchAll(roots);
+    long sample0 = sampleTouchLiveH2(roots, Math.min(TOUCH_SAMPLES_PER_CYCLE, 10_000), rnd);
+
+    System.out.println("Initial verifier acc=" + baseline);
+    System.out.println("Initial sentinel acc=" + sentinelBaseline);
+    System.out.println("Initial sample-touch acc=" + sample0);
+
+    for (int cycle = 0; cycle < CYCLES; cycle++) {
+      System.out.println("\n=== cycle " + cycle + " ===");
+
+      // Start CM and interrupt quickly.
+      GC.cm_start();
+      GC.young_gc();
+
+      // Create garbage inside H2: null out random slots.
+      System.out.println("Nulling H2 slots: " + NULL_SLOTS_PER_CYCLE);
+      for (int n = 0; n < NULL_SLOTS_PER_CYCLE; n++) {
+        Object[] r = roots[rnd.nextInt(NUM_ROOTS)];
+        if (r == null) continue;
+        r[rnd.nextInt(ROOT_LEN)] = null;
+      }
+
+      // Drop whole H2 roots to exercise "free region" path.
+      if (DROP_ROOT_EVERY > 0 && (cycle % DROP_ROOT_EVERY) == 0) {
+        int drops = Math.max(1, NUM_ROOTS / 16);
+        System.out.println("Dropping " + drops + " whole H2 roots");
+        for (int d = 0; d < drops; d++) {
+          int ri = rnd.nextInt(NUM_ROOTS);
+          roots[ri] = null;
+        }
+      }
+
+      // Storm young GCs while CM is in progress; keep mutating H2 and H2->H1 edges.
+      System.out.println("Young GC storm: " + YOUNG_GC_STORM);
+      for (int i = 0; i < YOUNG_GC_STORM; i++) {
+        GC.young_gc();
+
+        Object[] r = roots[rnd.nextInt(NUM_ROOTS)];
+        if (r != null) {
+          int j = rnd.nextInt(ROOT_LEN);
+
+          if ((i & 0x3FF) == 0) {
+            // Occasionally replace slot with a new H2 payload.
+            H2Payload p = new H2Payload((int) (id++), BLOB_KB);
+
+            // Rarely set H2 -> H1(humongous) edge.
+            if ((i & HUMONGOUS_MUTATE_MASK) == 0) {
+              p.maybeRef = newHumongousH1((int) (id++), H1_HUM_MIN_MB, H1_HUM_MAX_MB, rnd);
+            } else if ((i & 0x7) == 0 && j > 0) {
+              // Sometimes create H2->H2 edge.
+              Object prev = r[j - 1];
+              if (prev instanceof H2Payload) p.maybeRef = prev;
+            }
+
+            r[j] = p;
+
+          } else if ((i & 0x1FF) == 0) {
+            // Occasionally clear it.
+            r[j] = null;
+
+          } else if ((i & 0x3FF) == 1) {
+            // Occasionally mutate an existing H2 object's maybeRef to stress barriers/cards.
+            Object o = r[j];
+            if (o instanceof H2Payload) {
+              H2Payload p = (H2Payload) o;
+              if ((i & EDGE_MUTATE_MASK) == 0) {
+                p.maybeRef = newHumongousH1((int) (id++), H1_HUM_MIN_MB, H1_HUM_MAX_MB, rnd);
+              } else if ((i & 0xFFF) == 0) {
+                p.maybeRef = null;
+              }
+            }
+          }
+        }
+
+        if ((i % 5000) == 0 && i != 0) {
+          System.out.println("  storm progress " + i + "/" + YOUNG_GC_STORM);
+        }
+      }
+
+      // Finish CM + post-CM cleanup.
+      GC.wait_cm();
+      GC.gc();
+
+      // Strong verification: touch everything reachable from live H2 roots.
+      long acc = verifyAndTouchAll(roots);
+      System.out.println("Verifier acc=" + acc);
+
+      // Sentinel check: must remain stable unless you intentionally mutate sentinels.
+      long sentAcc = touchSentinels(sentinelRoot);
+      System.out.println("Sentinel acc=" + sentAcc);
+
+      if (sentAcc != sentinelBaseline) {
+        throw new AssertionError("Sentinel accumulator changed! was=" + sentinelBaseline +
+            " now=" + sentAcc + " (possible false free / corruption / stale pointer)");
+      }
+
+      // Sample-touch (probabilistic extra coverage).
+      long samp = sampleTouchLiveH2(roots, TOUCH_SAMPLES_PER_CYCLE, rnd);
+      System.out.println("Sample-touch acc=" + samp);
+    }
+
+    stop.set(true);
+
+    // Final GCs to push reclamation further.
+    for (int i = 0; i < 10; i++) GC.gc();
+
+    long fin = verifyAndTouchAll(roots);
+    long finSent = touchSentinels(sentinelRoot);
+    long finSamp = sampleTouchLiveH2(roots, Math.min(TOUCH_SAMPLES_PER_CYCLE, 50_000), rnd);
+
+    System.out.println("\nDone.");
+    System.out.println("Final verifier acc=" + fin);
+    System.out.println("Final sentinel acc=" + finSent);
+    System.out.println("Final sample-touch acc=" + finSamp);
+
+    if (finSent != sentinelBaseline) {
+      throw new AssertionError("Final sentinel accumulator changed! was=" + sentinelBaseline +
+          " now=" + finSent);
+    }
+  }
+}

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -85,6 +85,9 @@ set_heap_size() {
     Test_H2_CM_YoungInterrupt)
       H1_SZ=4
       ;;
+    Test_H2_FreePath_CM_YoungStorm)
+      H1_SZ=70
+      ;;
     *)
       H1_SZ=1
       ;;


### PR DESCRIPTION
CM cycle:
- Reset H2 region used-bits at the young GC that initiates a CM cycle.
- Reclaim unused H2 regions at the end of that young GC (before mixed GCs).

Full GC:
- Reset H2 region used-bits at the beginning of the Full GC marking phase.
- Reclaim unused H2 regions at the end of the Full GC marking phase.

Fix Full GC dependency tracking bug:
- During the adjust phase, objects that reference H2 were not considered for grouping.
- This could move an H2-transfer candidate to a different region without recording the referenced H2 region in the dependency list, causing the referenced region to not be marked used in the next cycle and to be reclaimed incorrectly.

Additional changes:
- Add per-GC statistics for reclaimed H2 regions.
- Clear card-table entries corresponding to each reclaimed H2 region.
- Add Java stress tests to exercise H2 reclamation paths (CM + young storms + Full GC).