### PR TITLE
Sync smartsweep with java17_g1_teraheap

### DIFF
--- a/jdk17/src/hotspot/share/gc/g1/g1FullCollector.hpp
+++ b/jdk17/src/hotspot/share/gc/g1/g1FullCollector.hpp
@@ -113,6 +113,7 @@ public:
 
   inline void set_invalid(uint region_idx);
   inline void update_from_compacting_to_skip_compacting(uint region_idx);
+  inline void set_compacting_for_humongous(HeapRegion* hum_start);
 
   template<class T> static inline bool h2_should_trace(T* p);
 

--- a/jdk17/src/hotspot/share/gc/g1/g1FullCollector.hpp
+++ b/jdk17/src/hotspot/share/gc/g1/g1FullCollector.hpp
@@ -103,6 +103,12 @@ public:
     return _live_stats[region_index]._live_words;
   }
 
+  size_t h2_live_words(uint region_index) {
+    assert(region_index < _heap->max_regions(), "sanity");
+    return _live_stats[region_index]._h2_live_words;
+  }
+
+
   void before_marking_update_attribute_table(HeapRegion* hr);
 
   inline bool should_compact_humongous(HeapRegion* hr) const;

--- a/jdk17/src/hotspot/share/gc/g1/g1FullCollector.inline.hpp
+++ b/jdk17/src/hotspot/share/gc/g1/g1FullCollector.inline.hpp
@@ -60,6 +60,18 @@ void G1FullCollector::update_from_compacting_to_skip_compacting(uint region_idx)
   _region_attr_table.set_skip_compacting(region_idx);
 }
 
+void G1FullCollector::set_compacting_for_humongous(HeapRegion* hum_start) {
+  if (!EnableTeraHeap)
+    return;
+
+  assert(hum_start->is_humongous()
+         && hum_start == hum_start->humongous_start_region()
+         && cast_to_oop(hum_start->bottom())->is_marked_move_h2(),
+         "Region should be the beginning of H2 candidate Humongous object");
+
+  _region_attr_table.set_compacting(hum_start->hrm_index());
+}
+
 template<class T>
 inline bool G1FullCollector::h2_should_trace(T* p) {
   T heap_oop = RawAccess<>::oop_load(p);

--- a/jdk17/src/hotspot/share/gc/g1/g1FullGCMarker.inline.hpp
+++ b/jdk17/src/hotspot/share/gc/g1/g1FullGCMarker.inline.hpp
@@ -112,6 +112,7 @@ template <class T> inline void G1FullGCMarker::mark_and_push(T* p) {
       // Object is an H2 candidate
       if (!obj->is_marked_move_h2() && !Universe::teraHeap()->is_metadata(obj)) {
         obj->mark_move_h2(_h2_group_id, _h2_part_id);
+        _mark_stats_cache.add_h2_live_words(obj); // estimation: may double calculate an object
       }
 #ifdef TERA_DBG_PHASES
       if (Universe::teraHeap()->is_metadata(obj))

--- a/jdk17/src/hotspot/share/gc/g1/g1FullGCOopClosures.inline.hpp
+++ b/jdk17/src/hotspot/share/gc/g1/g1FullGCOopClosures.inline.hpp
@@ -75,7 +75,7 @@ template <class T> inline void G1AdjustClosure::adjust_pointer(T* p) {
     // We never move objects in H2 so we shouldn't need to process them.
     return;
   }
-  if (!_collector->is_compacting(obj) && !obj->is_marked_move_h2()) {
+  if (!_collector->is_compacting(obj)) {
     // We never forward objects in non-compacting regions so there is no need to
     // process them further.
     // TODO: probably remove this assertion

--- a/jdk17/src/hotspot/share/gc/g1/g1FullGCPrepareTask.cpp
+++ b/jdk17/src/hotspot/share/gc/g1/g1FullGCPrepareTask.cpp
@@ -84,6 +84,9 @@ bool G1FullGCPrepareTask::G1CalculatePointersClosure::do_heap_region(HeapRegion*
       assert(MarkSweepDeadRatio > 0,
              "only skip compaction for other regions when MarkSweepDeadRatio > 0");
 
+      if (EnableTeraHeap && TeraHeapStatistics)
+        Universe::teraHeap()->get_tera_stats()->thr_add_regions_skipped(_worker_id, 1);
+
       // Too many live objects; skip compacting it.
       _collector->update_from_compacting_to_skip_compacting(hr->hrm_index());
       if (hr->is_young()) {
@@ -128,6 +131,9 @@ void G1FullGCPrepareTask::work(uint worker_id) {
 
   compaction_point->update();
 
+  if (EnableTeraHeap && TeraHeapStatistics)
+    Universe::teraHeap()->get_tera_stats()->thr_add_regions_scanned(worker_id, compaction_point->regions()->length());
+
   // Check if any regions was freed by this worker and store in task.
   if (closure.freed_regions()) {
     set_freed_regions();
@@ -149,13 +155,15 @@ bool G1FullGCPrepareTask::G1CalculatePointersClosure::should_compact(HeapRegion*
   if (hr->is_pinned()) {
     return false;
   }
+
   size_t live_words = _collector->live_words(hr->hrm_index());
+  size_t h2_live_words = _collector->h2_live_words(hr->hrm_index());
   size_t live_words_threshold = _collector->scope()->region_compaction_threshold();
+
   // High live ratio region will not be compacted.
-  // return live_words <= live_words_threshold;
-  // FIXME: ignore threshold for now. Should patch it later.
   if (EnableTeraHeap) {
-    return true;
+    // If the region however has h2 candidates, it is better to compact
+    return live_words <= live_words_threshold || h2_live_words > 0;
   } else {
     return live_words <= live_words_threshold;
   }

--- a/jdk17/src/hotspot/share/gc/g1/g1FullGCPrepareTask.cpp
+++ b/jdk17/src/hotspot/share/gc/g1/g1FullGCPrepareTask.cpp
@@ -278,6 +278,7 @@ void G1FullGCPrepareTask::G1CalculatePointersClosure::prepare_humongous_for_h2(H
 
   obj->forward_to(cast_to_oop(h2_address));
   Universe::teraHeap()->h2_push_humongous_start((void *)hr);
+  _collector->set_compacting_for_humongous(hr);
 }
 
 void G1FullGCPrepareTask::prepare_serial_compaction() {

--- a/jdk17/src/hotspot/share/gc/teraHeap/teraStatistics.cpp
+++ b/jdk17/src/hotspot/share/gc/teraHeap/teraStatistics.cpp
@@ -74,6 +74,9 @@ TeraStatistics::TeraStatistics() {
   thlog_or_tty->flush();
 #endif // RUSAGE_MUTATOR
 
+  thr_fgc_regions_scanned = NEW_C_HEAP_ARRAY(int, ParallelGCThreads, mtGC);
+  thr_fgc_regions_skipped = NEW_C_HEAP_ARRAY(int, ParallelGCThreads, mtGC);
+
   reset_counters();
 }
 
@@ -83,6 +86,9 @@ void TeraStatistics::reset_counters(void) {
 
   memset(thr_time_alloc_h2, 0, ParallelGCThreads * sizeof(double));
   memset(thr_time_copy_h2, 0, ParallelGCThreads * sizeof(double));
+
+  memset(thr_fgc_regions_scanned, 0, ParallelGCThreads * sizeof(int));
+  memset(thr_fgc_regions_skipped, 0, ParallelGCThreads * sizeof(int));
 }
 
 // Increase by one the counter that shows the total number of
@@ -158,6 +164,9 @@ void TeraStatistics::print_gc_stats() {
     thlog_or_tty->print_cr("[FULL] | TIME_SCAN_H2_CT %.3lf ms", h2_card_table_scan_time_ms);
     thlog_or_tty->print_cr("[FULL] | TIME_TO_ALLOC_H2 %.3lf ms", h2_allocate_ms);
     thlog_or_tty->print_cr("[FULL] | TIME_TO_COPY_H2 %.3lf ms (accurate for single threaded)", h2_copy_ms);
+    
+    thlog_or_tty->print_cr("[FULL] | Regions Scanned = %d", get_total_regions_scanned());
+    thlog_or_tty->print_cr("[FULL] | Regions Skipped = %d", get_total_regions_skipped());
   } else {
     // Young
     thlog_or_tty->print_cr("[YOUNG] | BACK_PTRS = %lu", backward_ref);
@@ -282,4 +291,26 @@ void TeraStatistics::h2_print_fwd_ref_stat() {
 	fwd_ref_histo.clear();
 }
 #endif
+
+void TeraStatistics::thr_add_regions_scanned(uint thread_id, int num_regions) {
+  thr_fgc_regions_scanned[thread_id] += num_regions;
+}
+
+void TeraStatistics::thr_add_regions_skipped(uint thread_id, int num_regions) {
+  thr_fgc_regions_skipped[thread_id] += num_regions;
+}
+
+int TeraStatistics::get_total_regions_scanned() {
+  int num_regions = 0;
+  for (uint i = 0; i < ParallelGCThreads; i++)
+    num_regions += thr_fgc_regions_scanned[i];
+  return num_regions;
+}
+
+int TeraStatistics::get_total_regions_skipped() {
+  int num_regions = 0;
+  for (uint i = 0; i < ParallelGCThreads; i++)
+    num_regions += thr_fgc_regions_skipped[i];
+  return num_regions;
+}
 

--- a/jdk17/src/hotspot/share/gc/teraHeap/teraStatistics.hpp
+++ b/jdk17/src/hotspot/share/gc/teraHeap/teraStatistics.hpp
@@ -73,6 +73,9 @@ private:
   std::map<oop, int> fwd_ref_histo;
 #endif
 
+  int *thr_fgc_regions_scanned;
+  int *thr_fgc_regions_skipped;
+
 public:
 
   TeraStatistics();
@@ -220,12 +223,18 @@ public:
   void h2_print_fwd_ref_stat();
 #endif
 
+  void thr_add_regions_scanned(uint thread_id, int num_regions);
+  void thr_add_regions_skipped(uint thread_id, int num_regions);
+
 private:
 
   double get_max_thr_time_alloc_h2();
 
   double get_max_thr_time_copy_h2();
 
+  int get_total_regions_scanned();
+
+  int get_total_regions_skipped();
 };
 
 #endif // SHARE_GC_TERAHEAP_TERASTATISTICS_HPP


### PR DESCRIPTION
This PR merges upstream updates to ensure smartsweep is based on the most recent version of java17_g1_teraheap.

## Included Updates
- [fix][g1full] Mark Humongous start regions as compacting
- [patch][g1full] Re-enable G1 threshold for region compaction
- Any additional commits merged into java17_g1_teraheap since the branch point