### PR TITLE
[feat] Adjust cost model to distinguish copy costs from H1->H1 and H1…

### DIFF
--- a/jdk17/src/hotspot/share/gc/g1/g1Analytics.cpp
+++ b/jdk17/src/hotspot/share/gc/g1/g1Analytics.cpp
@@ -88,12 +88,14 @@ G1Analytics::G1Analytics(const G1Predictions* predictor) :
     _young_cost_per_card_merge_ms_seq(new TruncatedSeq(TruncatedSeqLength)),
     _mixed_cost_per_card_merge_ms_seq(new TruncatedSeq(TruncatedSeqLength)),
     _copy_cost_per_byte_ms_seq(new TruncatedSeq(TruncatedSeqLength)),
+    _h2_copy_cost_per_byte_ms_seq(new TruncatedSeq(TruncatedSeqLength)), 
     _constant_other_time_ms_seq(new TruncatedSeq(TruncatedSeqLength)),
     _young_other_cost_per_region_ms_seq(new TruncatedSeq(TruncatedSeqLength)),
     _non_young_other_cost_per_region_ms_seq(new TruncatedSeq(TruncatedSeqLength)),
     _pending_cards_seq(new TruncatedSeq(TruncatedSeqLength)),
     _rs_length_seq(new TruncatedSeq(TruncatedSeqLength)),
     _cost_per_byte_ms_during_cm_seq(new TruncatedSeq(TruncatedSeqLength)),
+    _h2_cost_per_byte_ms_during_cm_seq(new TruncatedSeq(TruncatedSeqLength)), 
     _recent_prev_end_times_for_all_gcs_sec(new TruncatedSeq(NumPrevPausesForHeuristics)),
     _long_term_pause_time_ratio(0.0),
     _short_term_pause_time_ratio(0.0) {
@@ -113,6 +115,7 @@ G1Analytics::G1Analytics(const G1Predictions* predictor) :
   _young_cost_per_card_scan_ms_seq->add(young_only_cost_per_card_scan_ms_defaults[index]);
 
   _copy_cost_per_byte_ms_seq->add(cost_per_byte_ms_defaults[index]);
+  _h2_copy_cost_per_byte_ms_seq->add(cost_per_byte_ms_defaults[index]);
   _constant_other_time_ms_seq->add(constant_other_time_ms_defaults[index]);
   _young_other_cost_per_region_ms_seq->add(young_other_cost_per_region_ms_defaults[index]);
   _non_young_other_cost_per_region_ms_seq->add(non_young_other_cost_per_region_ms_defaults[index]);
@@ -205,6 +208,14 @@ void G1Analytics::report_cost_per_byte_ms(double cost_per_byte_ms, bool mark_or_
   }
 }
 
+void G1Analytics::report_h2_cost_per_byte_ms(double h2_cost_per_byte_ms, bool mark_or_rebuild_in_progress) {
+  if (mark_or_rebuild_in_progress) {
+    _h2_cost_per_byte_ms_during_cm_seq->add(h2_cost_per_byte_ms);
+  } else {
+    _h2_copy_cost_per_byte_ms_seq->add(h2_cost_per_byte_ms);
+  }
+}
+
 void G1Analytics::report_young_other_cost_per_region_ms(double other_cost_per_region_ms) {
   _young_other_cost_per_region_ms_seq->add(other_cost_per_region_ms);
 }
@@ -273,11 +284,27 @@ double G1Analytics::predict_object_copy_time_ms_during_cm(size_t bytes_to_copy) 
   }
 }
 
+double G1Analytics::predict_h2_object_copy_time_ms_during_cm(size_t h2_bytes_to_copy) const {
+  if (!enough_samples_available(_h2_cost_per_byte_ms_during_cm_seq)) {
+    return (1.1 * h2_bytes_to_copy) * predict_zero_bounded(_h2_copy_cost_per_byte_ms_seq);
+  } else {
+    return h2_bytes_to_copy * predict_zero_bounded(_h2_cost_per_byte_ms_during_cm_seq);
+  }
+}
+
 double G1Analytics::predict_object_copy_time_ms(size_t bytes_to_copy, bool during_concurrent_mark) const {
   if (during_concurrent_mark) {
     return predict_object_copy_time_ms_during_cm(bytes_to_copy);
   } else {
     return bytes_to_copy * predict_zero_bounded(_copy_cost_per_byte_ms_seq);
+  }
+}
+
+double G1Analytics::predict_h2_object_copy_time_ms(size_t h2_bytes_to_copy, bool during_concurrent_mark) const {
+  if (during_concurrent_mark) {
+    return predict_h2_object_copy_time_ms_during_cm(h2_bytes_to_copy);
+  } else {
+    return h2_bytes_to_copy * predict_zero_bounded(_h2_copy_cost_per_byte_ms_seq);
   }
 }
 

--- a/jdk17/src/hotspot/share/gc/g1/g1Analytics.hpp
+++ b/jdk17/src/hotspot/share/gc/g1/g1Analytics.hpp
@@ -63,6 +63,7 @@ class G1Analytics: public CHeapObj<mtGC> {
 
   // The cost to copy a byte in ms.
   TruncatedSeq* _copy_cost_per_byte_ms_seq;
+  TruncatedSeq* _h2_copy_cost_per_byte_ms_seq; 
   TruncatedSeq* _constant_other_time_ms_seq;
   TruncatedSeq* _young_other_cost_per_region_ms_seq;
   TruncatedSeq* _non_young_other_cost_per_region_ms_seq;
@@ -71,6 +72,7 @@ class G1Analytics: public CHeapObj<mtGC> {
   TruncatedSeq* _rs_length_seq;
 
   TruncatedSeq* _cost_per_byte_ms_during_cm_seq;
+  TruncatedSeq* _h2_cost_per_byte_ms_during_cm_seq; 
 
   // Statistics kept per GC stoppage, pause or full.
   TruncatedSeq* _recent_prev_end_times_for_all_gcs_sec;
@@ -128,6 +130,7 @@ public:
   void report_card_merge_to_scan_ratio(double cards_per_entry_ratio, bool for_young_gc);
   void report_rs_length_diff(double rs_length_diff);
   void report_cost_per_byte_ms(double cost_per_byte_ms, bool mark_or_rebuild_in_progress);
+  void report_h2_cost_per_byte_ms(double h2_cost_per_byte_ms, bool mark_or_rebuild_in_progress); 
   void report_young_other_cost_per_region_ms(double other_cost_per_region_ms);
   void report_non_young_other_cost_per_region_ms(double other_cost_per_region_ms);
   void report_constant_other_time_ms(double constant_other_time_ms);
@@ -149,8 +152,10 @@ public:
   double predict_card_scan_time_ms(size_t card_num, bool for_young_gc) const;
 
   double predict_object_copy_time_ms_during_cm(size_t bytes_to_copy) const;
+  double predict_h2_object_copy_time_ms_during_cm(size_t h2_bytes_to_copy) const;
 
   double predict_object_copy_time_ms(size_t bytes_to_copy, bool during_concurrent_mark) const;
+  double predict_h2_object_copy_time_ms(size_t h2_bytes_to_copy, bool during_concurrent_mark) const;
 
   double predict_constant_other_time_ms() const;
 

--- a/jdk17/src/hotspot/share/gc/g1/g1FullGCCompactTask.cpp
+++ b/jdk17/src/hotspot/share/gc/g1/g1FullGCCompactTask.cpp
@@ -73,13 +73,15 @@ size_t G1FullGCCompactTask::G1CompactRegionClosure::apply(oop obj) {
   if (EnableTeraHeap && Universe::teraHeap()->is_in_h2(destination)) {
     // Move object to H2
     if (TeraHeapStatistics) {
-      Ticks start = Ticks::now();
+      double start = os::elapsedTime();
 
       obj->init_mark();
       Universe::teraHeap()->h2_move_obj(obj_addr, destination, size, true /* in fgc */);
 
-      Tickspan time = Ticks::now() - start;
-      Universe::teraHeap()->get_tera_stats()->thr_add_time_copy_h2(_worker_id, TimeHelper::counter_to_millis(time.value()));
+      double time = os::elapsedTime() - start;
+      Universe::teraHeap()->get_tera_stats()->thr_add_time_copy_h2(_worker_id, time);
+      Universe::teraHeap()->get_tera_stats()->thr_add_bytes_copy_h2(_worker_id, size);
+
     } else {
       obj->init_mark();
       Universe::teraHeap()->h2_move_obj(obj_addr, destination, size, true /* in fgc */);
@@ -128,13 +130,15 @@ void G1FullGCCompactTask::h2_move_humongous(HeapRegion* hr, uint worker_id) {
 
   // Move object to H2
   if (TeraHeapStatistics) {
-    Ticks start = Ticks::now();
+    double start = os::elapsedTime();
 
     obj->init_mark();
     Universe::teraHeap()->h2_move_obj(obj_addr, destination, size, true /* in fgc */);
 
-    Tickspan time = Ticks::now() - start;
-    Universe::teraHeap()->get_tera_stats()->thr_add_time_copy_h2(worker_id, TimeHelper::counter_to_millis(time.value()));
+    double time = os::elapsedTime() - start;
+    Universe::teraHeap()->get_tera_stats()->thr_add_time_copy_h2(worker_id, time);
+    Universe::teraHeap()->get_tera_stats()->thr_add_bytes_copy_h2(worker_id, size);
+
   } else {
     obj->init_mark();
     Universe::teraHeap()->h2_move_obj(obj_addr, destination, size, true /* in fgc */);

--- a/jdk17/src/hotspot/share/gc/g1/g1FullGCPrepareTask.cpp
+++ b/jdk17/src/hotspot/share/gc/g1/g1FullGCPrepareTask.cpp
@@ -191,12 +191,12 @@ size_t G1FullGCPrepareTask::G1PrepareCompactLiveClosure::apply(oop object) {
     if (TeraHeapStatistics) {
       Universe::teraHeap()->get_tera_stats()->add_object( object->size()*HeapWordSize );
 
-      Ticks start = Ticks::now();
+      double start = os::elapsedTime();
 
       h2_address = (HeapWord *) Universe::teraHeap()->h2_add_object(object, size);
 
-      Tickspan time = Ticks::now() - start;
-      Universe::teraHeap()->get_tera_stats()->thr_add_time_alloc_h2(_worker_id, TimeHelper::counter_to_millis(time.value()));
+      double time = os::elapsedTime() - start;
+      Universe::teraHeap()->get_tera_stats()->thr_add_time_alloc_h2(_worker_id, time);
     } else {
       h2_address = (HeapWord *) Universe::teraHeap()->h2_add_object(object, size);
     }
@@ -263,12 +263,12 @@ void G1FullGCPrepareTask::G1CalculatePointersClosure::prepare_humongous_for_h2(H
   if (TeraHeapStatistics) {
     Universe::teraHeap()->get_tera_stats()->add_object( obj->size()*HeapWordSize );
 
-    Ticks start = Ticks::now();
+    double start = os::elapsedTime();
 
     h2_address = (HeapWord *) Universe::teraHeap()->h2_add_object(obj, obj->size());
 
-    Tickspan time = Ticks::now() - start;
-    Universe::teraHeap()->get_tera_stats()->thr_add_time_alloc_h2(_worker_id, TimeHelper::counter_to_millis(time.value()));
+    double time = os::elapsedTime() - start;
+    Universe::teraHeap()->get_tera_stats()->thr_add_time_alloc_h2(_worker_id, time);
   } else {
     h2_address = (HeapWord *) Universe::teraHeap()->h2_add_object(obj, obj->size());
   }

--- a/jdk17/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
+++ b/jdk17/src/hotspot/share/gc/g1/g1ParScanThreadState.cpp
@@ -663,12 +663,12 @@ oop G1ParScanThreadState::do_copy_to_h2_space(G1HeapRegionAttr const region_attr
   if (TeraHeapStatistics) {
     Universe::teraHeap()->get_tera_stats()->add_object( obj->size()*HeapWordSize );
 
-    Ticks start = Ticks::now();
+    double start = os::elapsedTime();
 
     h2_obj_addr = (HeapWord*) Universe::teraHeap()->h2_add_object(obj, word_sz);
 
-    Tickspan time = Ticks::now() - start;
-    Universe::teraHeap()->get_tera_stats()->thr_add_time_alloc_h2(_worker_id, TimeHelper::counter_to_millis(time.value()));
+    double time = os::elapsedTime() - start;
+    Universe::teraHeap()->get_tera_stats()->thr_add_time_alloc_h2(_worker_id, time);
   } else {
     h2_obj_addr = (HeapWord*) Universe::teraHeap()->h2_add_object(obj, word_sz);
   }
@@ -704,12 +704,14 @@ oop G1ParScanThreadState::do_copy_to_h2_space(G1HeapRegionAttr const region_attr
   // ----------------------------------
 
   if (TeraHeapStatistics) {
-    Ticks start = Ticks::now();
+    double start = os::elapsedTime();
 
     Universe::teraHeap()->h2_move_obj(cast_from_oop<HeapWord*>(obj), h2_obj_addr, word_sz);
 
-    Tickspan time = Ticks::now() - start;
-    Universe::teraHeap()->get_tera_stats()->thr_add_time_copy_h2(_worker_id, TimeHelper::counter_to_millis(time.value()));
+    double time = os::elapsedTime() - start;
+    Universe::teraHeap()->get_tera_stats()->thr_add_time_copy_h2(_worker_id, time);
+    Universe::teraHeap()->get_tera_stats()->thr_add_bytes_copy_h2(_worker_id, word_sz);
+    
   } else {
     Universe::teraHeap()->h2_move_obj(cast_from_oop<HeapWord*>(obj), h2_obj_addr, word_sz);
   }

--- a/jdk17/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/jdk17/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -746,11 +746,33 @@ void G1Policy::record_collection_pause_end(double pause_time_ms, bool concurrent
 
     // Update prediction for copy cost per byte
     size_t copied_bytes = p->sum_thread_work_items(G1GCPhaseTimes::MergePSS, G1GCPhaseTimes::MergePSSCopiedBytes);
+   
+  #ifdef TWO_FACTOR_COST_MODEL_IN_CSET
+      
+      size_t copied_bytes_h2 = 0;
+      double average_time_ms_h2 = 0.0;
+
+      if (EnableTeraHeap && TeraHeapStatistics) {
+        copied_bytes_h2 = Universe::teraHeap()->get_tera_stats()->get_sum_thr_bytes_copy_h2();
+        average_time_ms_h2 = Universe::teraHeap()->get_tera_stats()->get_average_time_ms_h2();
+      }
+
+  #endif
+  
 
     if (copied_bytes > 0) {
       double cost_per_byte_ms = (average_time_ms(G1GCPhaseTimes::ObjCopy) + average_time_ms(G1GCPhaseTimes::OptObjCopy)) / copied_bytes;
       _analytics->report_cost_per_byte_ms(cost_per_byte_ms, collector_state()->mark_or_rebuild_in_progress());
     }
+
+  #ifdef TWO_FACTOR_COST_MODEL_IN_CSET
+    if(copied_bytes_h2 > 0){
+      if(EnableTeraHeap && TeraHeapStatistics){
+        double cost_h2_per_byte_ms = average_time_ms_h2 / copied_bytes_h2;
+        _analytics->report_h2_cost_per_byte_ms(cost_h2_per_byte_ms, collector_state()->mark_or_rebuild_in_progress());
+      }
+    }
+  #endif
 
     if (_collection_set->young_region_length() > 0) {
       _analytics->report_young_other_cost_per_region_ms(young_other_time_ms() /
@@ -927,6 +949,29 @@ size_t G1Policy::predict_bytes_to_copy(HeapRegion* hr) const {
   return bytes_to_copy;
 }
 
+size_t G1Policy::predict_h2_bytes_to_copy(HeapRegion* hr) const {
+  //During young gc we do not transfer objects to h2 so cost time is zero  
+  if(!(_g1h->collector_state()->in_mixed_phase())) return 0;
+
+  size_t h2_bytes_to_copy = 0;
+  if (!hr->is_young()) {
+#ifdef TERA_CONC_MARKING
+   
+    //bytes to copy in H2
+    if (EnableTeraHeap)
+      h2_bytes_to_copy = hr->h2_marked_bytes();
+    else
+      h2_bytes_to_copy = 0;
+#else
+    h2_bytes_to_copy = 0;
+#endif
+  } else { 
+    h2_bytes_to_copy = 0;
+  }
+  return h2_bytes_to_copy;
+}
+
+
 double G1Policy::predict_eden_copy_time_ms(uint count, size_t* bytes_to_copy) const {
   if (count == 0) {
     return 0.0;
@@ -940,7 +985,14 @@ double G1Policy::predict_eden_copy_time_ms(uint count, size_t* bytes_to_copy) co
 
 double G1Policy::predict_region_copy_time_ms(HeapRegion* hr) const {
   size_t const bytes_to_copy = predict_bytes_to_copy(hr);
+
+#ifdef TWO_FACTOR_COST_MODEL_IN_CSET
+  size_t const h2_bytes_to_copy = predict_h2_bytes_to_copy(hr);
+  return _analytics->predict_object_copy_time_ms(bytes_to_copy, collector_state()->mark_or_rebuild_in_progress()) + _analytics->predict_h2_object_copy_time_ms(h2_bytes_to_copy, collector_state()->mark_or_rebuild_in_progress());
+#else 
   return _analytics->predict_object_copy_time_ms(bytes_to_copy, collector_state()->mark_or_rebuild_in_progress());
+#endif
+
 }
 
 double G1Policy::predict_region_non_copy_time_ms(HeapRegion* hr,

--- a/jdk17/src/hotspot/share/gc/g1/g1Policy.hpp
+++ b/jdk17/src/hotspot/share/gc/g1/g1Policy.hpp
@@ -236,6 +236,7 @@ private:
   void update_rs_length_prediction(size_t prediction);
 
   size_t predict_bytes_to_copy(HeapRegion* hr) const;
+  size_t predict_h2_bytes_to_copy(HeapRegion* hr) const;  
   double predict_survivor_regions_evac_time() const;
 
   // Check whether a given young length (young_length) fits into the

--- a/jdk17/src/hotspot/share/gc/teraHeap/teraStatistics.cpp
+++ b/jdk17/src/hotspot/share/gc/teraHeap/teraStatistics.cpp
@@ -44,6 +44,7 @@ TeraStatistics::TeraStatistics() {
   // NOTE: these arrays are not freed as the destructor is never called
   thr_time_alloc_h2 = NEW_C_HEAP_ARRAY(double, ParallelGCThreads, mtGC);
   thr_time_copy_h2 = NEW_C_HEAP_ARRAY(double, ParallelGCThreads, mtGC);
+  thr_bytes_copy_h2 = NEW_C_HEAP_ARRAY(size_t, ParallelGCThreads, mtGC);
 
   h2_card_table_scan_time_ms = 0;
   evac_time_ms = 0;
@@ -88,6 +89,7 @@ void TeraStatistics::reset_counters(void) {
 
   memset(thr_time_alloc_h2, 0, ParallelGCThreads * sizeof(double));
   memset(thr_time_copy_h2, 0, ParallelGCThreads * sizeof(double));
+  memset(thr_bytes_copy_h2, 0, ParallelGCThreads * sizeof(size_t));
 
   memset(thr_fgc_regions_scanned, 0, ParallelGCThreads * sizeof(int));
   memset(thr_fgc_regions_skipped, 0, ParallelGCThreads * sizeof(int));
@@ -128,6 +130,10 @@ void TeraStatistics::thr_add_time_alloc_h2(uint thread_id, double time) {
 
 void TeraStatistics::thr_add_time_copy_h2(uint thread_id, double time) {
   thr_time_copy_h2[thread_id] += time;
+}
+
+void TeraStatistics::thr_add_bytes_copy_h2(uint thread_id, size_t bytes) {
+  thr_bytes_copy_h2[thread_id] += bytes;
 }
 
 void TeraStatistics::add_obj_size_distribution(size_t size) {
@@ -208,6 +214,57 @@ double TeraStatistics::get_max_thr_time_copy_h2() {
   }
 
   return max_time;
+}
+
+double TeraStatistics::get_sum_thr_time_alloc_h2(){
+  double sum_time = 0.0;
+  for(uint i = 0; i < ParallelGCThreads; i++){
+    sum_time += thr_time_alloc_h2[i];
+  }
+  return sum_time;
+}
+
+double TeraStatistics::get_sum_thr_time_copy_h2(){
+  double sum_time = 0.0;
+  for(uint i = 0; i < ParallelGCThreads; i++){
+    sum_time += thr_time_copy_h2[i];
+  }
+  return sum_time;
+}
+
+size_t TeraStatistics::get_sum_thr_bytes_copy_h2(){
+  size_t sum_bytes = 0;
+  for(uint i = 0; i < ParallelGCThreads; i++){
+    sum_bytes += thr_bytes_copy_h2[i];
+  }
+  return sum_bytes;
+}
+
+double TeraStatistics::get_average_time_ms_h2() {
+  uint contributing_threads_alloc = 0, contributing_threads_copy = 0;
+
+  for(uint i = 0; i < ParallelGCThreads; i++){
+    if(thr_time_alloc_h2[i] != 0) contributing_threads_alloc++;
+    if(thr_time_copy_h2[i] != 0) contributing_threads_copy++;
+  }
+
+  double sum_time_copy = get_sum_thr_time_copy_h2();
+  double sum_time_alloc = get_sum_thr_time_alloc_h2();
+
+  double avg_copy = 0.0, avg_alloc = 0.0;
+
+  if(contributing_threads_alloc == 0) {
+    avg_alloc = 0.0;
+  } else {
+    avg_alloc = sum_time_alloc / (double) contributing_threads_alloc;
+  }
+
+  if(contributing_threads_copy == 0) {
+    avg_copy = 0.0;
+  } else {
+    avg_copy = sum_time_copy / (double) contributing_threads_copy;
+  }
+  return (avg_copy + avg_alloc)* 1000.0;
 }
 
 #ifdef BACK_REF_STAT

--- a/jdk17/src/hotspot/share/gc/teraHeap/teraStatistics.hpp
+++ b/jdk17/src/hotspot/share/gc/teraHeap/teraStatistics.hpp
@@ -34,6 +34,7 @@ private:
 
   double* thr_time_alloc_h2;
   double* thr_time_copy_h2;
+  size_t* thr_bytes_copy_h2;
 
   // total time of allocation to H2
   double h2_allocate_ms;
@@ -109,6 +110,9 @@ public:
   // Add the time it took for a thread to make a copy to H2
   void thr_add_time_copy_h2(uint thread_id, double time);
 
+  // Add the size of object that a thread copied to H2
+  void thr_add_bytes_copy_h2(uint thread_id, size_t bytes);
+  
   // Increase the appropriate counter for the distribution
   // NOTE: call when adding objects to H2
   void add_obj_size_distribution(size_t size);
@@ -137,6 +141,9 @@ public:
   void record_h2_max_copy_time() {
     h2_copy_ms = get_max_thr_time_copy_h2();
   }
+
+  double get_average_time_ms_h2(); 
+  size_t get_sum_thr_bytes_copy_h2();
 
   void set_is_in_mix(bool is_mixed_gc) {
     _is_mixed_gc = is_mixed_gc;
@@ -235,6 +242,10 @@ private:
   double get_max_thr_time_alloc_h2();
 
   double get_max_thr_time_copy_h2();
+
+  double get_sum_thr_time_alloc_h2();
+
+  double get_sum_thr_time_copy_h2(); 
 
   int get_total_regions_scanned();
 

--- a/jdk17/src/hotspot/share/memory/sharedDefines.h
+++ b/jdk17/src/hotspot/share/memory/sharedDefines.h
@@ -131,6 +131,8 @@
 
 #define VISITED_TERA_OBJ  203     //< Object visited during GC Analysis
 
+#define TWO_FACTOR_COST_MODEL_IN_CSET // Use cost model with different cost per byte metrics for h1 and h2 bytes, or not
+
 // #define RUSAGE_MUTATOR  //< Enables rusage measuremetns excluding STW GCs
 
 #endif  // _SHARE_DEFINES_H_


### PR DESCRIPTION
Introduce distinct H1→H1 and H1→H2 copy‑cost components and integrate time‑series weighting into the new cost‑per‑byte predictor. Enhances candidate‑list reordering and improves per‑region cost estimation for old‑CSet selection.